### PR TITLE
Mobile 1180 Remove CoroutineScope and unify interfaces naming

### DIFF
--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingFragment.kt
@@ -9,7 +9,7 @@ import eu.kevin.accounts.accountlinking.AccountLinkingIntent.HandleBackClicked
 import eu.kevin.accounts.accountlinking.AccountLinkingIntent.Initialize
 import eu.kevin.common.architecture.BaseFragment
 import eu.kevin.common.architecture.interfaces.DeepLinkHandler
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.helpers.IntentHandlerHelper
 import eu.kevin.common.helpers.WebFrameHelper
 import eu.kevin.core.plugin.Kevin
@@ -27,7 +27,7 @@ internal class AccountLinkingFragment :
         AccountLinkingViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<AccountLinkingState> {
+    override fun onCreateView(context: Context): View<AccountLinkingState> {
         return AccountLinkingView(context).also {
             it.delegate = this
             view = it

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingIntent.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingIntent.kt
@@ -1,9 +1,9 @@
 package eu.kevin.accounts.accountlinking
 
 import android.net.Uri
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class AccountLinkingIntent : IIntent {
+internal sealed class AccountLinkingIntent : Intent {
     data class Initialize(
         val configuration: AccountLinkingFragmentConfiguration,
         val webFrameQueryParameters: String

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingState.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingState.kt
@@ -2,11 +2,11 @@ package eu.kevin.accounts.accountlinking
 
 import android.os.Parcelable
 import eu.kevin.accounts.accountsession.enums.AccountLinkingType
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class AccountLinkingState(
     val bankRedirectUrl: String = "",
     val accountLinkingType: AccountLinkingType = AccountLinkingType.BANK
-) : IState, Parcelable
+) : State, Parcelable

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingView.kt
@@ -12,7 +12,7 @@ import eu.kevin.accounts.R
 import eu.kevin.accounts.accountsession.enums.AccountLinkingType
 import eu.kevin.accounts.databinding.KevinFragmentAccountLinkingBinding
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.applySystemInsetsMargin
 import eu.kevin.common.extensions.applySystemInsetsPadding
 import eu.kevin.common.extensions.dp
@@ -22,7 +22,7 @@ import eu.kevin.common.managers.KeyboardManager
 
 internal class AccountLinkingView(context: Context) :
     BaseView<KevinFragmentAccountLinkingBinding>(context),
-    IView<AccountLinkingState> {
+    View<AccountLinkingState> {
 
     override val binding = KevinFragmentAccountLinkingBinding.inflate(LayoutInflater.from(context), this)
 

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionFragment.kt
@@ -13,7 +13,7 @@ import eu.kevin.accounts.bankselection.BankSelectionIntent.HandleCountrySelectio
 import eu.kevin.accounts.bankselection.BankSelectionIntent.Initialize
 import eu.kevin.accounts.countryselection.CountrySelectionContract
 import eu.kevin.common.architecture.BaseFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.setFragmentResultListener
 
 internal class BankSelectionFragment :
@@ -26,7 +26,7 @@ internal class BankSelectionFragment :
         BankSelectionViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<BankSelectionState> {
+    override fun onCreateView(context: Context): View<BankSelectionState> {
         return BankSelectionView(context).also {
             it.delegate = this
         }

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionIntent.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionIntent.kt
@@ -1,8 +1,8 @@
 package eu.kevin.accounts.bankselection
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class BankSelectionIntent : IIntent {
+internal sealed class BankSelectionIntent : Intent {
     data class Initialize(val configuration: BankSelectionFragmentConfiguration) : BankSelectionIntent()
     data class HandleCountrySelectionClick(
         val configuration: BankSelectionFragmentConfiguration

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionState.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionState.kt
@@ -2,7 +2,7 @@ package eu.kevin.accounts.bankselection
 
 import android.os.Parcelable
 import eu.kevin.accounts.bankselection.entities.BankListItem
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.common.entities.LoadingState
 import kotlinx.parcelize.Parcelize
 
@@ -12,4 +12,4 @@ internal data class BankSelectionState(
     val isCountrySelectionDisabled: Boolean = true,
     val bankListItems: List<BankListItem> = emptyList(),
     val loadingState: LoadingState? = null
-) : IState, Parcelable
+) : State, Parcelable

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
@@ -11,7 +11,7 @@ import eu.kevin.accounts.bankselection.exceptions.BankNotSelectedException
 import eu.kevin.accounts.countryselection.helpers.CountryHelper
 import eu.kevin.accounts.databinding.KevinFragmentBankSelectionBinding
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.common.entities.isLoading
 import eu.kevin.common.extensions.applySystemInsetsMargin
@@ -28,7 +28,7 @@ import eu.kevin.common.views.GridListItemDecoration
 
 internal class BankSelectionView(context: Context) :
     BaseView<KevinFragmentBankSelectionBinding>(context),
-    IView<BankSelectionState> {
+    View<BankSelectionState> {
 
     override val binding = KevinFragmentBankSelectionBinding.inflate(LayoutInflater.from(context), this)
 

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/managers/BankManager.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/managers/BankManager.kt
@@ -2,6 +2,6 @@ package eu.kevin.accounts.bankselection.managers
 
 import eu.kevin.accounts.networking.entities.ApiBank
 
-interface BankManagerInterface {
+interface BankManager {
     suspend fun getSupportedBanks(country: String, authState: String): List<ApiBank>
 }

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/managers/KevinBankManager.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/managers/KevinBankManager.kt
@@ -5,7 +5,7 @@ import eu.kevin.accounts.networking.entities.ApiBank
 
 class KevinBankManager(
     private val kevinAccountsClient: KevinAccountsClient
-) : BankManagerInterface {
+) : BankManager {
     override suspend fun getSupportedBanks(country: String, authState: String): List<ApiBank> {
         return kevinAccountsClient.getSupportedBanks(authState, country).data
     }

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/usecases/GetSupportedBanksUseCase.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/usecases/GetSupportedBanksUseCase.kt
@@ -1,11 +1,11 @@
 package eu.kevin.accounts.bankselection.usecases
 
 import eu.kevin.accounts.bankselection.entities.SupportedBanksFilter
-import eu.kevin.accounts.bankselection.managers.BankManagerInterface
+import eu.kevin.accounts.bankselection.managers.BankManager
 import eu.kevin.accounts.networking.entities.ApiBank
 
 internal class GetSupportedBanksUseCase(
-    private val bankManager: BankManagerInterface
+    private val bankManager: BankManager
 ) {
     suspend fun getSupportedBanks(
         country: String,

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionFragment.kt
@@ -5,7 +5,7 @@ import androidx.fragment.app.viewModels
 import eu.kevin.accounts.countryselection.CountrySelectionIntent.HandleCountrySelection
 import eu.kevin.accounts.countryselection.CountrySelectionIntent.Initialize
 import eu.kevin.common.architecture.BaseModalFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 
 internal class CountrySelectionFragment :
     BaseModalFragment<CountrySelectionState, CountrySelectionIntent, CountrySelectionViewModel>(),
@@ -17,7 +17,7 @@ internal class CountrySelectionFragment :
         CountrySelectionViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<CountrySelectionState> {
+    override fun onCreateView(context: Context): View<CountrySelectionState> {
         return CountrySelectionView(context).also {
             it.delegate = this
         }

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionIntent.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionIntent.kt
@@ -1,8 +1,8 @@
 package eu.kevin.accounts.countryselection
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class CountrySelectionIntent : IIntent {
+internal sealed class CountrySelectionIntent : Intent {
     data class Initialize(val configuration: CountrySelectionFragmentConfiguration) : CountrySelectionIntent()
     data class HandleCountrySelection(val iso: String) : CountrySelectionIntent()
 }

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionState.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionState.kt
@@ -2,7 +2,7 @@ package eu.kevin.accounts.countryselection
 
 import android.os.Parcelable
 import eu.kevin.accounts.countryselection.entities.Country
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.common.entities.LoadingState
 import kotlinx.parcelize.Parcelize
 
@@ -10,4 +10,4 @@ import kotlinx.parcelize.Parcelize
 internal data class CountrySelectionState(
     val supportedCountries: List<Country> = emptyList(),
     val loadingState: LoadingState? = null
-) : IState, Parcelable
+) : State, Parcelable

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionView.kt
@@ -8,7 +8,7 @@ import eu.kevin.accounts.countryselection.entities.Country
 import eu.kevin.accounts.countryselection.helpers.CountryHelper
 import eu.kevin.accounts.databinding.KevinFragmentCountrySelectionBinding
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.common.entities.isLoading
 import eu.kevin.common.extensions.applySystemInsetsPadding
@@ -19,7 +19,7 @@ import eu.kevin.common.helpers.SnackbarHelper
 
 internal class CountrySelectionView(context: Context) :
     BaseView<KevinFragmentCountrySelectionBinding>(context),
-    IView<CountrySelectionState> {
+    View<CountrySelectionState> {
 
     override val binding = KevinFragmentCountrySelectionBinding.inflate(LayoutInflater.from(context), this)
 

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/managers/CountriesManager.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/managers/CountriesManager.kt
@@ -1,5 +1,5 @@
 package eu.kevin.accounts.countryselection.managers
 
-interface CountriesManagerInterface {
+interface CountriesManager {
     suspend fun getSupportedCountries(authState: String): List<String>
 }

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/managers/KevinCountriesManager.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/managers/KevinCountriesManager.kt
@@ -4,7 +4,7 @@ import eu.kevin.accounts.networking.KevinAccountsClient
 
 class KevinCountriesManager(
     private val kevinAccountsClient: KevinAccountsClient
-) : CountriesManagerInterface {
+) : CountriesManager {
 
     override suspend fun getSupportedCountries(authState: String): List<String> {
         return kevinAccountsClient.getSupportedCountries(authState).data

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/usecases/SupportedCountryUseCase.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/usecases/SupportedCountryUseCase.kt
@@ -1,10 +1,10 @@
 package eu.kevin.accounts.countryselection.usecases
 
-import eu.kevin.accounts.countryselection.managers.CountriesManagerInterface
+import eu.kevin.accounts.countryselection.managers.CountriesManager
 import eu.kevin.core.enums.KevinCountry
 
 internal class SupportedCountryUseCase(
-    private val countriesManager: CountriesManagerInterface
+    private val countriesManager: CountriesManager
 ) {
 
     suspend fun getSupportedCountries(authState: String, filter: List<KevinCountry>): List<String> {

--- a/accounts/src/test/java/eu/kevin/accounts/bankselection/BankSelectionViewModelTest.kt
+++ b/accounts/src/test/java/eu/kevin/accounts/bankselection/BankSelectionViewModelTest.kt
@@ -3,9 +3,9 @@ package eu.kevin.accounts.bankselection
 import android.os.Bundle
 import eu.kevin.accounts.bankselection.entities.Bank
 import eu.kevin.accounts.bankselection.factories.BankListItemFactory
-import eu.kevin.accounts.bankselection.managers.BankTestManager
+import eu.kevin.accounts.bankselection.managers.TestBankManager
 import eu.kevin.accounts.bankselection.usecases.GetSupportedBanksUseCase
-import eu.kevin.accounts.countryselection.managers.CountriesTestManager
+import eu.kevin.accounts.countryselection.managers.TestCountriesManager
 import eu.kevin.accounts.countryselection.usecases.SupportedCountryUseCase
 import eu.kevin.common.architecture.routing.GlobalRouter
 import eu.kevin.common.entities.LoadingState
@@ -33,8 +33,8 @@ class BankSelectionViewModelTest : BaseViewModelTest() {
     override fun setUp() {
         super.setUp()
         viewModel = BankSelectionViewModel(
-            SupportedCountryUseCase(CountriesTestManager()),
-            GetSupportedBanksUseCase(BankTestManager()),
+            SupportedCountryUseCase(TestCountriesManager()),
+            GetSupportedBanksUseCase(TestBankManager()),
             TestCoroutineDispatchers,
             savedStateHandle
         )
@@ -150,7 +150,7 @@ class BankSelectionViewModelTest : BaseViewModelTest() {
         val preselectedBank = "SWEDBANK_LT"
         viewModel.updateInternalState(
             BankSelectionState(
-                bankListItems = BankListItemFactory.getBankList(BankTestManager().getSupportedBanks("lt", ""), null)
+                bankListItems = BankListItemFactory.getBankList(TestBankManager().getSupportedBanks("lt", ""), null)
             )
         )
         val states = mutableListOf<BankSelectionState>()

--- a/accounts/src/test/java/eu/kevin/accounts/bankselection/managers/TestBankManager.kt
+++ b/accounts/src/test/java/eu/kevin/accounts/bankselection/managers/TestBankManager.kt
@@ -2,7 +2,7 @@ package eu.kevin.accounts.bankselection.managers
 
 import eu.kevin.accounts.networking.entities.ApiBank
 
-class BankTestManager : BankManagerInterface {
+class TestBankManager : BankManager {
 
     override suspend fun getSupportedBanks(country: String, authState: String): List<ApiBank> {
         val banks = listOf(

--- a/accounts/src/test/java/eu/kevin/accounts/countryselection/CountrySelectionViewModelTest.kt
+++ b/accounts/src/test/java/eu/kevin/accounts/countryselection/CountrySelectionViewModelTest.kt
@@ -1,7 +1,7 @@
 package eu.kevin.accounts.countryselection
 
 import eu.kevin.accounts.countryselection.entities.Country
-import eu.kevin.accounts.countryselection.managers.CountriesTestManager
+import eu.kevin.accounts.countryselection.managers.TestCountriesManager
 import eu.kevin.accounts.countryselection.usecases.SupportedCountryUseCase
 import eu.kevin.common.architecture.routing.GlobalRouter
 import eu.kevin.common.entities.LoadingState
@@ -29,7 +29,7 @@ class CountrySelectionViewModelTest : BaseViewModelTest() {
     override fun setUp() {
         super.setUp()
         viewModel = CountrySelectionViewModel(
-            SupportedCountryUseCase(CountriesTestManager()),
+            SupportedCountryUseCase(TestCountriesManager()),
             TestCoroutineDispatchers,
             savedStateHandle
         )
@@ -86,7 +86,7 @@ class CountrySelectionViewModelTest : BaseViewModelTest() {
     fun `test handleIntent() HandleCountrySelection`() = testCoroutineScope.runTest {
         viewModel.updateInternalState(
             CountrySelectionState(
-                CountriesTestManager().getSupportedCountries("").map {
+                TestCountriesManager().getSupportedCountries("").map {
                     Country(it)
                 }
             )

--- a/accounts/src/test/java/eu/kevin/accounts/countryselection/managers/TestCountriesManager.kt
+++ b/accounts/src/test/java/eu/kevin/accounts/countryselection/managers/TestCountriesManager.kt
@@ -1,6 +1,6 @@
 package eu.kevin.accounts.countryselection.managers
 
-class CountriesTestManager : CountriesManagerInterface {
+class TestCountriesManager : CountriesManager {
 
     override suspend fun getSupportedCountries(authState: String): List<String> {
         return listOf(

--- a/accounts/src/test/java/eu/kevin/accounts/countryselection/usecases/SupportedCountryUseCaseTest.kt
+++ b/accounts/src/test/java/eu/kevin/accounts/countryselection/usecases/SupportedCountryUseCaseTest.kt
@@ -1,6 +1,6 @@
 package eu.kevin.accounts.countryselection.usecases
 
-import eu.kevin.accounts.countryselection.managers.CountriesTestManager
+import eu.kevin.accounts.countryselection.managers.TestCountriesManager
 import eu.kevin.core.enums.KevinCountry
 import eu.kevin.testcore.base.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,7 +17,7 @@ class SupportedCountryUseCaseTest : BaseUnitTest() {
     @Before
     override fun setUp() {
         super.setUp()
-        countryUseCase = SupportedCountryUseCase(CountriesTestManager())
+        countryUseCase = SupportedCountryUseCase(TestCountriesManager())
     }
 
     @Test

--- a/common/src/main/java/eu/kevin/common/architecture/BaseFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseFragment.kt
@@ -6,10 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import eu.kevin.common.architecture.interfaces.IIntent
-import eu.kevin.common.architecture.interfaces.IState
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.common.architecture.interfaces.Navigable
+import eu.kevin.common.architecture.interfaces.State
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.providers.SavedStateProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
 
-abstract class BaseFragment<S : IState, I : IIntent, M : BaseViewModel<S, I>> :
+abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
     Fragment(),
     CoroutineScope,
     Navigable {
@@ -30,9 +30,9 @@ abstract class BaseFragment<S : IState, I : IIntent, M : BaseViewModel<S, I>> :
     private val savable = Bundle()
 
     protected abstract val viewModel: M
-    protected lateinit var contentView: IView<S>
+    protected lateinit var contentView: eu.kevin.common.architecture.interfaces.View<S>
 
-    abstract fun onCreateView(context: Context): IView<S>
+    abstract fun onCreateView(context: Context): eu.kevin.common.architecture.interfaces.View<S>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {

--- a/common/src/main/java/eu/kevin/common/architecture/BaseFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseFragment.kt
@@ -3,7 +3,6 @@ package eu.kevin.common.architecture
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import eu.kevin.common.architecture.interfaces.Intent
@@ -18,6 +17,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
+import android.view.View as ViewAndroid
 
 abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
     Fragment(),
@@ -30,9 +30,9 @@ abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
     private val savable = Bundle()
 
     protected abstract val viewModel: M
-    protected lateinit var contentView: eu.kevin.common.architecture.interfaces.View<S>
+    protected lateinit var contentView: View<S>
 
-    abstract fun onCreateView(context: Context): eu.kevin.common.architecture.interfaces.View<S>
+    abstract fun onCreateView(context: Context): View<S>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {
@@ -45,12 +45,12 @@ abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): ViewAndroid? {
         job = SupervisorJob()
         observeChanges()
         return onCreateView(inflater.context).also {
             contentView = it
-        } as View
+        } as ViewAndroid
     }
 
     override fun onDestroyView() {

--- a/common/src/main/java/eu/kevin/common/architecture/BaseFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseFragment.kt
@@ -5,28 +5,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.common.architecture.interfaces.Navigable
 import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.providers.SavedStateProvider
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.launch
 import android.view.View as ViewAndroid
 
 abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
     Fragment(),
-    CoroutineScope,
     Navigable {
 
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + job
-    private lateinit var job: Job
     private val savable = Bundle()
 
     protected abstract val viewModel: M
@@ -46,16 +39,23 @@ abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): ViewAndroid? {
-        job = SupervisorJob()
-        observeChanges()
         return onCreateView(inflater.context).also {
             contentView = it
         } as ViewAndroid
     }
 
-    override fun onDestroyView() {
-        job.cancel()
-        super.onDestroyView()
+    override fun onViewCreated(view: ViewAndroid, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(viewLifecycleOwner) {
+            lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    viewModel.state.collect {
+                        contentView.render(it)
+                    }
+                }
+            }
+        }
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
@@ -70,15 +70,7 @@ abstract class BaseFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
 
     protected open fun onAttached() {}
 
-    override fun onBackPressed(): Boolean {
-        return false
-    }
-
-    private fun observeChanges() {
-        viewModel.state.onEach {
-            contentView.render(it)
-        }.launchIn(this)
-    }
+    override fun onBackPressed(): Boolean = false
 
     protected fun <T> savedState() = SavedStateProvider.Nullable<T>(savable)
     protected fun <T> savedState(defaultValue: T) = SavedStateProvider.NotNull(savable, defaultValue)

--- a/common/src/main/java/eu/kevin/common/architecture/BaseModalFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseModalFragment.kt
@@ -6,10 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import eu.kevin.common.architecture.interfaces.IIntent
-import eu.kevin.common.architecture.interfaces.IState
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.common.architecture.interfaces.Navigable
+import eu.kevin.common.architecture.interfaces.State
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.providers.SavedStateProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
 
-abstract class BaseModalFragment<S : IState, I : IIntent, M : BaseViewModel<S, I>> :
+abstract class BaseModalFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
     BottomSheetDialogFragment(),
     CoroutineScope,
     Navigable {
@@ -30,9 +30,9 @@ abstract class BaseModalFragment<S : IState, I : IIntent, M : BaseViewModel<S, I
     private val savable = Bundle()
 
     protected abstract val viewModel: M
-    protected lateinit var contentView: IView<S>
+    protected lateinit var contentView: eu.kevin.common.architecture.interfaces.View<S>
 
-    abstract fun onCreateView(context: Context): IView<S>
+    abstract fun onCreateView(context: Context): eu.kevin.common.architecture.interfaces.View<S>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {

--- a/common/src/main/java/eu/kevin/common/architecture/BaseModalFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseModalFragment.kt
@@ -3,7 +3,6 @@ package eu.kevin.common.architecture
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import eu.kevin.common.architecture.interfaces.Intent
@@ -18,6 +17,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlin.coroutines.CoroutineContext
+import android.view.View as ViewAndroid
 
 abstract class BaseModalFragment<S : State, I : Intent, M : BaseViewModel<S, I>> :
     BottomSheetDialogFragment(),
@@ -30,9 +30,9 @@ abstract class BaseModalFragment<S : State, I : Intent, M : BaseViewModel<S, I>>
     private val savable = Bundle()
 
     protected abstract val viewModel: M
-    protected lateinit var contentView: eu.kevin.common.architecture.interfaces.View<S>
+    protected lateinit var contentView: View<S>
 
-    abstract fun onCreateView(context: Context): eu.kevin.common.architecture.interfaces.View<S>
+    abstract fun onCreateView(context: Context): View<S>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {
@@ -45,12 +45,12 @@ abstract class BaseModalFragment<S : State, I : Intent, M : BaseViewModel<S, I>>
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): ViewAndroid? {
         job = SupervisorJob()
         observeChanges()
         return onCreateView(inflater.context).also {
             contentView = it
-        } as View
+        } as ViewAndroid
     }
 
     override fun onDestroyView() {

--- a/common/src/main/java/eu/kevin/common/architecture/BaseStatelessModalFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseStatelessModalFragment.kt
@@ -8,20 +8,11 @@ import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import eu.kevin.common.architecture.interfaces.Navigable
 import eu.kevin.common.providers.SavedStateProvider
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlin.coroutines.CoroutineContext
 
 abstract class BaseStatelessModalFragment :
     BottomSheetDialogFragment(),
-    CoroutineScope,
     Navigable {
 
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main + job
-    private lateinit var job: Job
     private val savable = Bundle()
 
     abstract fun onCreateView(context: Context): View
@@ -37,15 +28,7 @@ abstract class BaseStatelessModalFragment :
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        job = SupervisorJob()
-        return onCreateView(inflater.context)
-    }
-
-    override fun onDestroyView() {
-        job.cancel()
-        super.onDestroyView()
-    }
+    ): View? = onCreateView(inflater.context)
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
@@ -59,9 +42,7 @@ abstract class BaseStatelessModalFragment :
 
     protected open fun onAttached() {}
 
-    override fun onBackPressed(): Boolean {
-        return false
-    }
+    override fun onBackPressed(): Boolean = false
 
     protected fun <T> savedState() = SavedStateProvider.Nullable<T>(savable)
     protected fun <T> savedState(defaultValue: T) = SavedStateProvider.NotNull(savable, defaultValue)

--- a/common/src/main/java/eu/kevin/common/architecture/BaseViewModel.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseViewModel.kt
@@ -3,9 +3,9 @@ package eu.kevin.common.architecture
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import eu.kevin.common.architecture.interfaces.IIntent
-import eu.kevin.common.architecture.interfaces.IModel
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.Intent
+import eu.kevin.common.architecture.interfaces.Model
+import eu.kevin.common.architecture.interfaces.State
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,9 +13,9 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-abstract class BaseViewModel<S : IState, I : IIntent>(
+abstract class BaseViewModel<S : State, I : Intent>(
     protected val savedStateHandle: SavedStateHandle
-) : ViewModel(), IModel<S, I> {
+) : ViewModel(), Model<S, I> {
 
     override val intents = Channel<I>(Channel.UNLIMITED)
     override val state: StateFlow<S>

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/Intent.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/Intent.kt
@@ -1,3 +1,3 @@
 package eu.kevin.common.architecture.interfaces
 
-interface IIntent
+interface Intent

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/Model.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/Model.kt
@@ -3,7 +3,7 @@ package eu.kevin.common.architecture.interfaces
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.StateFlow
 
-interface IModel<S : IState, I : IIntent> {
+interface Model<S : State, I : Intent> {
     val intents: Channel<I>
     val state: StateFlow<S?>
 }

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/State.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/State.kt
@@ -1,3 +1,3 @@
 package eu.kevin.common.architecture.interfaces
 
-interface IState
+interface State

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/View.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/View.kt
@@ -1,5 +1,5 @@
 package eu.kevin.common.architecture.interfaces
 
-interface IView<S : IState> {
+interface View<S : State> {
     fun render(state: S)
 }

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsFragment.kt
@@ -3,7 +3,7 @@ package eu.kevin.demo.screens.accountactions
 import android.content.Context
 import androidx.fragment.app.viewModels
 import eu.kevin.common.architecture.BaseModalFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.demo.screens.accountactions.AccountActionsIntent.HandleRemoveAccount
 
 internal class AccountActionsFragment :
@@ -22,7 +22,7 @@ internal class AccountActionsFragment :
         viewModel.initialise(configuration!!)
     }
 
-    override fun onCreateView(context: Context): IView<AccountActionsState> {
+    override fun onCreateView(context: Context): View<AccountActionsState> {
         return AccountActionsView(context).also {
             it.callback = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsIntent.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsIntent.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.screens.accountactions
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class AccountActionsIntent : IIntent {
+internal sealed class AccountActionsIntent : Intent {
     data class HandleRemoveAccount(val id: Long) : AccountActionsIntent()
 }

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsState.kt
@@ -1,10 +1,10 @@
 package eu.kevin.demo.screens.accountactions
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class AccountActionsState(
     val bankName: String = ""
-) : IState, Parcelable
+) : State, Parcelable

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsView.kt
@@ -3,13 +3,13 @@ package eu.kevin.demo.screens.accountactions
 import android.content.Context
 import android.view.LayoutInflater
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.applySystemInsetsPadding
 import eu.kevin.demo.databinding.KevinFragmentAccountActionsBinding
 
 internal class AccountActionsView(context: Context) :
     BaseView<KevinFragmentAccountActionsBinding>(context),
-    IView<AccountActionsState> {
+    View<AccountActionsState> {
 
     override val binding = KevinFragmentAccountActionsBinding.inflate(LayoutInflater.from(context), this)
 

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingFragment.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.lifecycleScope
 import eu.kevin.accounts.accountsession.AccountSessionContract
 import eu.kevin.accounts.accountsession.entities.AccountSessionConfiguration
 import eu.kevin.common.architecture.BaseFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.setFragmentResultListener
 import eu.kevin.core.enums.KevinCountry
 import eu.kevin.demo.screens.accountactions.AccountActionsContract
@@ -31,7 +31,7 @@ internal class AccountLinkingFragment :
         viewModel.intents.trySend(OnAccountLinkingResult(result))
     }
 
-    override fun onCreateView(context: Context): IView<AccountLinkingState> {
+    override fun onCreateView(context: Context): View<AccountLinkingState> {
         observeChanges()
         listenForAccountActionSelectedResult()
         return AccountLinkingView(context).also {

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingIntent.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingIntent.kt
@@ -1,11 +1,11 @@
 package eu.kevin.demo.screens.accountlinking
 
 import eu.kevin.accounts.accountsession.AccountSessionResult
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.core.entities.SessionResult
 import eu.kevin.demo.screens.accountactions.entities.AccountAction
 
-internal sealed class AccountLinkingIntent : IIntent {
+internal sealed class AccountLinkingIntent : Intent {
     object OnStartAccountLinking : AccountLinkingIntent()
     data class OnAccountLinkingResult(
         val accountSessionResult: SessionResult<AccountSessionResult>

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingState.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.screens.accountlinking
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.demo.data.database.entities.LinkedAccount
 import kotlinx.parcelize.Parcelize
 
@@ -9,4 +9,4 @@ import kotlinx.parcelize.Parcelize
 internal data class AccountLinkingState(
     val isLoading: Boolean = false,
     val linkedAccounts: List<LinkedAccount> = emptyList()
-) : IState, Parcelable
+) : State, Parcelable

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingView.kt
@@ -6,13 +6,13 @@ import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.demo.R
 import eu.kevin.demo.databinding.KevinFragmentLinkAccountBinding
 import eu.kevin.demo.screens.accountlinking.adapters.LinkedAccountsListAdapter
 import eu.kevin.demo.views.DividerItemDecoration
 
-internal class AccountLinkingView(context: Context) : FrameLayout(context), IView<AccountLinkingState> {
+internal class AccountLinkingView(context: Context) : FrameLayout(context), View<AccountLinkingState> {
 
     var callback: AccountLinkingViewCallback? = null
 

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountFragment.kt
@@ -3,7 +3,7 @@ package eu.kevin.demo.screens.chooseaccount
 import android.content.Context
 import androidx.fragment.app.viewModels
 import eu.kevin.common.architecture.BaseModalFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.demo.screens.chooseaccount.ChooseAccountIntent.OnAccountChosen
 
 internal class ChooseAccountFragment :
@@ -16,7 +16,7 @@ internal class ChooseAccountFragment :
         )
     }
 
-    override fun onCreateView(context: Context): IView<ChooseAccountState> {
+    override fun onCreateView(context: Context): View<ChooseAccountState> {
         return ChooseAccountView(context).also {
             it.callback = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountIntent.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountIntent.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.screens.chooseaccount
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class ChooseAccountIntent : IIntent {
+internal sealed class ChooseAccountIntent : Intent {
     data class OnAccountChosen(val id: Long) : ChooseAccountIntent()
 }

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountState.kt
@@ -1,11 +1,11 @@
 package eu.kevin.demo.screens.chooseaccount
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.demo.data.database.entities.LinkedAccount
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class ChooseAccountState(
     val accounts: List<LinkedAccount> = emptyList()
-) : IState, Parcelable
+) : State, Parcelable

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountView.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.LinearLayoutManager
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.applySystemInsetsPadding
 import eu.kevin.demo.databinding.KevinFragmentChooseAccountBinding
 import eu.kevin.demo.screens.chooseaccount.adapters.AccountsListAdapter
 
 internal class ChooseAccountView(context: Context) :
     BaseView<KevinFragmentChooseAccountBinding>(context),
-    IView<ChooseAccountState> {
+    View<ChooseAccountState> {
 
     override val binding = KevinFragmentChooseAccountBinding.inflate(LayoutInflater.from(context), this)
 

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionFragment.kt
@@ -3,7 +3,7 @@ package eu.kevin.demo.screens.countryselection
 import android.content.Context
 import androidx.fragment.app.viewModels
 import eu.kevin.common.architecture.BaseModalFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.demo.screens.countryselection.CountrySelectionIntent.HandleCountrySelection
 import eu.kevin.demo.screens.countryselection.CountrySelectionIntent.Initialize
 
@@ -17,7 +17,7 @@ internal class CountrySelectionFragment :
         CountrySelectionViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<CountrySelectionState> {
+    override fun onCreateView(context: Context): View<CountrySelectionState> {
         return CountrySelectionView(context).also {
             it.delegate = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionIntent.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionIntent.kt
@@ -1,8 +1,8 @@
 package eu.kevin.demo.screens.countryselection
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class CountrySelectionIntent : IIntent {
+internal sealed class CountrySelectionIntent : Intent {
     data class Initialize(val configuration: CountrySelectionFragmentConfiguration) : CountrySelectionIntent()
     data class HandleCountrySelection(val iso: String) : CountrySelectionIntent()
 }

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionState.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.screens.countryselection
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.demo.screens.countryselection.entities.Country
 import kotlinx.parcelize.Parcelize
@@ -10,4 +10,4 @@ import kotlinx.parcelize.Parcelize
 internal data class CountrySelectionState(
     val supportedCountries: List<Country> = emptyList(),
     val loadingState: LoadingState? = null
-) : IState, Parcelable
+) : State, Parcelable

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionView.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import androidx.recyclerview.widget.LinearLayoutManager
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.common.entities.isLoading
 import eu.kevin.common.extensions.applySystemInsetsPadding
@@ -19,7 +19,7 @@ import eu.kevin.demo.screens.countryselection.helpers.CountryHelper
 
 internal class CountrySelectionView(context: Context) :
     BaseView<KevinFragmentSelectCountryBinding>(context),
-    IView<CountrySelectionState> {
+    View<CountrySelectionState> {
 
     override val binding = KevinFragmentSelectCountryBinding.inflate(LayoutInflater.from(context), this)
 

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentFragment.kt
@@ -6,7 +6,7 @@ import android.net.Uri
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import eu.kevin.common.architecture.BaseFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.setFragmentResultListener
 import eu.kevin.demo.screens.chooseaccount.ChooseAccountContract
 import eu.kevin.demo.screens.countryselection.CountrySelectionContract
@@ -39,7 +39,7 @@ internal class PaymentFragment :
         viewModel.intents.trySend(OnPaymentResult(result))
     }
 
-    override fun onCreateView(context: Context): IView<PaymentViewState> {
+    override fun onCreateView(context: Context): View<PaymentViewState> {
         observeChanges()
         listenForCountrySelectedResult()
         listenForPaymentTypeSelectedResult()

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentIntent.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentIntent.kt
@@ -1,13 +1,13 @@
 package eu.kevin.demo.screens.payment
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.core.entities.SessionResult
 import eu.kevin.demo.screens.payment.entities.CreditorListItem
 import eu.kevin.demo.screens.payment.entities.DonationRequest
 import eu.kevin.demo.screens.paymenttype.enums.DemoPaymentType
 import eu.kevin.inapppayments.paymentsession.PaymentSessionResult
 
-internal sealed class PaymentIntent : IIntent {
+internal sealed class PaymentIntent : Intent {
     data class OnCreditorSelected(val creditor: CreditorListItem) : PaymentIntent()
     data class OnCountrySelected(val iso: String) : PaymentIntent()
     data class OnPaymentTypeSelected(val paymentType: DemoPaymentType) : PaymentIntent()

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentView.kt
@@ -9,7 +9,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.widget.addTextChangedListener
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.common.entities.isLoading
 import eu.kevin.common.extensions.fadeIn
@@ -33,7 +33,7 @@ import eu.kevin.demo.screens.payment.entities.ValidationResult
 import eu.kevin.demo.screens.payment.entities.exceptions.CreditorNotSelectedException
 import eu.kevin.demo.views.NumberTextWatcher
 
-internal class PaymentView(context: Context) : FrameLayout(context), IView<PaymentViewState> {
+internal class PaymentView(context: Context) : FrameLayout(context), View<PaymentViewState> {
 
     var callback: PaymentViewCallback? = null
 

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentViewState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentViewState.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.screens.payment
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.demo.screens.payment.entities.CreditorListItem
 import kotlinx.parcelize.Parcelize
@@ -13,4 +13,4 @@ internal data class PaymentViewState(
     val creditors: List<CreditorListItem> = emptyList(),
     val buttonText: String = "0.00",
     val loadingCreditors: Boolean = false
-) : IState, Parcelable
+) : State, Parcelable

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeFragment.kt
@@ -3,7 +3,7 @@ package eu.kevin.demo.screens.paymenttype
 import android.content.Context
 import androidx.fragment.app.viewModels
 import eu.kevin.common.architecture.BaseModalFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.demo.screens.paymenttype.PaymentTypeIntent.Initialize
 import eu.kevin.demo.screens.paymenttype.PaymentTypeIntent.OnPaymentTypeChosen
 import eu.kevin.demo.screens.paymenttype.enums.DemoPaymentType
@@ -18,7 +18,7 @@ internal class PaymentTypeFragment :
         PaymentTypeViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<PaymentTypeState> {
+    override fun onCreateView(context: Context): View<PaymentTypeState> {
         return PaymentTypeView(context).also {
             it.callback = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeIntent.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeIntent.kt
@@ -1,9 +1,9 @@
 package eu.kevin.demo.screens.paymenttype
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.demo.screens.paymenttype.enums.DemoPaymentType
 
-internal sealed class PaymentTypeIntent : IIntent {
+internal sealed class PaymentTypeIntent : Intent {
     data class OnPaymentTypeChosen(val demoPaymentType: DemoPaymentType) : PaymentTypeIntent()
     data class Initialize(val paymentTypeFragmentConfiguration: PaymentTypeFragmentConfiguration) : PaymentTypeIntent()
 }

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeState.kt
@@ -1,10 +1,10 @@
 package eu.kevin.demo.screens.paymenttype
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 internal data class PaymentTypeState(
     val showLinkedAccountOption: Boolean = false
-) : IState, Parcelable
+) : State, Parcelable

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeView.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.view.LayoutInflater
 import androidx.core.view.isVisible
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.applySystemInsetsPadding
 import eu.kevin.demo.databinding.KevinFragmentPaymentTypeBinding
 
 internal class PaymentTypeView(context: Context) :
     BaseView<KevinFragmentPaymentTypeBinding>(context),
-    IView<PaymentTypeState> {
+    View<PaymentTypeState> {
 
     var callback: PaymentTypeViewCallback? = null
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentFragment.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import eu.kevin.common.architecture.BaseFragment
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.setFragmentResultListener
 import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandleBackClicked
 import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandleCardPaymentEvent
@@ -35,7 +35,7 @@ internal class CardPaymentFragment :
 
     private lateinit var view: CardPaymentView
 
-    override fun onCreateView(context: Context): IView<CardPaymentState> {
+    override fun onCreateView(context: Context): View<CardPaymentState> {
         return CardPaymentView(context).also {
             it.delegate = this
             view = it

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentIntent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentIntent.kt
@@ -1,10 +1,10 @@
 package eu.kevin.inapppayments.cardpayment
 
 import android.net.Uri
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent
 
-internal sealed class CardPaymentIntent : IIntent {
+internal sealed class CardPaymentIntent : Intent {
     object HandleBackClicked : CardPaymentIntent()
     object HandlePageStartLoading : CardPaymentIntent()
     object HandlePageFinishedLoading : CardPaymentIntent()

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentState.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentState.kt
@@ -1,7 +1,7 @@
 package eu.kevin.inapppayments.cardpayment
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import eu.kevin.common.entities.KevinAmount
 import eu.kevin.common.entities.LoadingState
 import kotlinx.parcelize.Parcelize
@@ -13,4 +13,4 @@ internal data class CardPaymentState(
     val showCardDetails: Boolean = true,
     val isContinueEnabled: Boolean = false,
     val loadingState: LoadingState? = null
-) : IState, Parcelable
+) : State, Parcelable

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentView.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentView.kt
@@ -12,7 +12,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.core.widget.addTextChangedListener
 import androidx.webkit.WebViewClientCompat
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.entities.LoadingState
 import eu.kevin.common.extensions.applySystemInsetsMargin
 import eu.kevin.common.extensions.applySystemInsetsPadding
@@ -40,7 +40,7 @@ import eu.kevin.inapppayments.databinding.KevinFragmentCardPaymentBinding
 
 internal class CardPaymentView(context: Context) :
     BaseView<KevinFragmentCardPaymentBinding>(context),
-    IView<CardPaymentState> {
+    View<CardPaymentState> {
 
     override val binding = KevinFragmentCardPaymentBinding.inflate(LayoutInflater.from(context), this)
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentViewAction.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentViewAction.kt
@@ -1,9 +1,9 @@
 package eu.kevin.inapppayments.cardpayment
 
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 import eu.kevin.inapppayments.cardpayment.inputvalidation.ValidationResult
 
-internal sealed class CardPaymentViewAction : IIntent {
+internal sealed class CardPaymentViewAction : Intent {
     data class ShowFieldValidations(
         val cardholderNameValidation: ValidationResult,
         val cardNumberValidation: ValidationResult,

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
@@ -6,7 +6,7 @@ import android.net.Uri
 import androidx.fragment.app.viewModels
 import eu.kevin.common.architecture.BaseFragment
 import eu.kevin.common.architecture.interfaces.DeepLinkHandler
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.helpers.IntentHandlerHelper
 import eu.kevin.common.helpers.WebFrameHelper
 import eu.kevin.core.plugin.Kevin
@@ -27,7 +27,7 @@ internal class PaymentConfirmationFragment :
 
     private lateinit var view: PaymentConfirmationView
 
-    override fun onCreateView(context: Context): IView<PaymentConfirmationState> {
+    override fun onCreateView(context: Context): View<PaymentConfirmationState> {
         return PaymentConfirmationView(context).also {
             it.delegate = this
             view = it

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationIntent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationIntent.kt
@@ -1,9 +1,9 @@
 package eu.kevin.inapppayments.paymentconfirmation
 
 import android.net.Uri
-import eu.kevin.common.architecture.interfaces.IIntent
+import eu.kevin.common.architecture.interfaces.Intent
 
-internal sealed class PaymentConfirmationIntent : IIntent {
+internal sealed class PaymentConfirmationIntent : Intent {
     data class Initialize(
         val configuration: PaymentConfirmationFragmentConfiguration,
         val webFrameQueryParameters: String

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationState.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationState.kt
@@ -1,10 +1,10 @@
 package eu.kevin.inapppayments.paymentconfirmation
 
 import android.os.Parcelable
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.State
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class PaymentConfirmationState(
     val url: String = ""
-) : IState, Parcelable
+) : State, Parcelable

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationView.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationView.kt
@@ -8,7 +8,7 @@ import android.webkit.WebView
 import androidx.core.view.updateLayoutParams
 import androidx.webkit.WebViewClientCompat
 import eu.kevin.common.architecture.BaseView
-import eu.kevin.common.architecture.interfaces.IView
+import eu.kevin.common.architecture.interfaces.View
 import eu.kevin.common.extensions.applySystemInsetsMargin
 import eu.kevin.common.extensions.applySystemInsetsPadding
 import eu.kevin.common.extensions.dp
@@ -20,7 +20,7 @@ import eu.kevin.inapppayments.databinding.KevinFragmentPaymentConfirmationBindin
 
 internal class PaymentConfirmationView(context: Context) :
     BaseView<KevinFragmentPaymentConfirmationBinding>(context),
-    IView<PaymentConfirmationState> {
+    View<PaymentConfirmationState> {
 
     override val binding = KevinFragmentPaymentConfirmationBinding.inflate(LayoutInflater.from(context), this)
 

--- a/testcore/src/main/java/eu/kevin/testcore/extensions/BaseViewModelExtensions.kt
+++ b/testcore/src/main/java/eu/kevin/testcore/extensions/BaseViewModelExtensions.kt
@@ -1,11 +1,11 @@
 package eu.kevin.testcore.extensions
 
 import eu.kevin.common.architecture.BaseViewModel
-import eu.kevin.common.architecture.interfaces.IIntent
-import eu.kevin.common.architecture.interfaces.IState
+import eu.kevin.common.architecture.interfaces.Intent
+import eu.kevin.common.architecture.interfaces.State
 import kotlinx.coroutines.flow.MutableStateFlow
 
-fun <S : IState, I : IIntent> BaseViewModel<S, I>.updateInternalState(newState: S) {
+fun <S : State, I : Intent> BaseViewModel<S, I>.updateInternalState(newState: S) {
     val field = BaseViewModel::class.java.getDeclaredField("_state")
     field.isAccessible = true
     field.set(this, MutableStateFlow(newState))


### PR DESCRIPTION
repeatOnLifecycle is now being used for Base* fragments. Other changes is just renaming.