### PR TITLE
MOBILE-1177: Update launchMode to singleTop

### DIFF
--- a/accounts/src/main/AndroidManifest.xml
+++ b/accounts/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         <activity
             android:name="eu.kevin.accounts.accountsession.AccountSessionActivity"
             android:exported="true"
-            android:launchMode="singleInstance" />
+            android:launchMode="singleTop" />
     </application>
 
 </manifest>

--- a/in-app-payments/src/main/AndroidManifest.xml
+++ b/in-app-payments/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         <activity
             android:name="eu.kevin.inapppayments.paymentsession.PaymentSessionActivity"
             android:exported="true"
-            android:launchMode="singleInstance" />
+            android:launchMode="singleTop" />
     </application>
 
 </manifest>


### PR DESCRIPTION
This PR fixes the problem with crashes related to new tasks creation. It will now match `Intent.FLAG_ACTIVITY_SINGLE_TOP` already used in code to launch activities.

Also did some testing of deep linking support with Revolut app and everything seems to be in order.

However if you have concerns I might not be aware of @edgar-zigis @aurimas-zarskis - let me know.