### PR TITLE
MOBILE-1192 Improve used for preventing reloading webviews

### DIFF
--- a/.github/workflows/checkKtlint.yml
+++ b/.github/workflows/checkKtlint.yml
@@ -1,21 +1,38 @@
-name: Check Lint
+name: Check Lint and Tests
 
 on:
   pull_request:
     branches: [ master, main ]
 
 jobs:
-  check_ktlint:
-    name: Check ktlint
+  setup:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v1
-
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
 
+  check_ktlint:
+    needs: setup
+    name: Check ktlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
       - name: Validate code using ktlint
         run: ./gradlew lintKotlinMain
+
+  check_tests:
+    needs: check_ktlint
+    name: Check unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run unit tests (:core)
+        run: ./gradlew :core:testDebugUnitTest
+      - name: Run unit tests (:accounts)
+        run: ./gradlew :accounts:testDebugUnitTest
+      - name: Run unit tests (:in-app-payments)
+        run: ./gradlew :in-app-payments:testDebugUnitTest

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingEvent.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingEvent.kt
@@ -1,0 +1,7 @@
+package eu.kevin.accounts.accountlinking
+
+import eu.kevin.common.architecture.interfaces.IEvent
+
+internal sealed class AccountLinkingEvent : IEvent {
+    data class LoadWebPage(val url: String) : AccountLinkingEvent()
+}

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingFragment.kt
@@ -15,7 +15,7 @@ import eu.kevin.common.helpers.WebFrameHelper
 import eu.kevin.core.plugin.Kevin
 
 internal class AccountLinkingFragment :
-    BaseFragment<AccountLinkingState, AccountLinkingIntent, AccountLinkingViewModel>(),
+    BaseFragment<AccountLinkingState, AccountLinkingIntent, AccountLinkingEvent, AccountLinkingViewModel>(),
     AccountLinkingViewDelegate,
     DeepLinkHandler {
 
@@ -27,7 +27,7 @@ internal class AccountLinkingFragment :
         AccountLinkingViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<AccountLinkingState> {
+    override fun onCreateView(context: Context): IView<AccountLinkingState, AccountLinkingEvent> {
         return AccountLinkingView(context).also {
             it.delegate = this
             view = it

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingState.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingState.kt
@@ -7,6 +7,5 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class AccountLinkingState(
-    val bankRedirectUrl: String = "",
     val accountLinkingType: AccountLinkingType = AccountLinkingType.BANK
 ) : IState, Parcelable

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingView.kt
@@ -9,6 +9,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.webkit.WebViewClientCompat
 import eu.kevin.accounts.KevinAccountsPlugin
 import eu.kevin.accounts.R
+import eu.kevin.accounts.accountlinking.AccountLinkingEvent.LoadWebPage
 import eu.kevin.accounts.accountsession.enums.AccountLinkingType
 import eu.kevin.accounts.databinding.KevinFragmentAccountLinkingBinding
 import eu.kevin.common.architecture.BaseView
@@ -22,14 +23,13 @@ import eu.kevin.common.managers.KeyboardManager
 
 internal class AccountLinkingView(context: Context) :
     BaseView<KevinFragmentAccountLinkingBinding>(context),
-    IView<AccountLinkingState> {
+    IView<AccountLinkingState, AccountLinkingEvent> {
 
     override val binding = KevinFragmentAccountLinkingBinding.inflate(LayoutInflater.from(context), this)
 
     var delegate: AccountLinkingViewDelegate? = null
 
     private var lastClickPosition: Int = 0
-    private var previousStateUrl: String? = null
 
     init {
         setBackgroundColor(context.getColorFromAttr(android.R.attr.colorBackground))
@@ -93,14 +93,21 @@ internal class AccountLinkingView(context: Context) :
     }
 
     override fun render(state: AccountLinkingState) = with(binding) {
-        if (state.bankRedirectUrl.isNotBlank() && state.bankRedirectUrl != previousStateUrl) {
-            accountLinkWebView.loadUrl(state.bankRedirectUrl)
-            previousStateUrl = state.bankRedirectUrl
-        }
+
         if (state.accountLinkingType == AccountLinkingType.BANK) {
             binding.actionBar.title = context.getString(R.string.kevin_window_account_linking_title)
         } else {
             binding.actionBar.title = context.getString(R.string.kevin_window_account_linking_card_title)
+        }
+    }
+
+    override fun handleEvent(event: AccountLinkingEvent) {
+        when (event) {
+            is LoadWebPage -> {
+                if (event.url.isNotBlank()) {
+                    binding.accountLinkWebView.loadUrl(event.url)
+                }
+            }
         }
     }
 

--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingViewModel.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
 import eu.kevin.accounts.BuildConfig
 import eu.kevin.accounts.KevinAccountsPlugin
+import eu.kevin.accounts.accountlinking.AccountLinkingEvent.LoadWebPage
 import eu.kevin.accounts.accountlinking.AccountLinkingIntent.HandleAuthorization
 import eu.kevin.accounts.accountlinking.AccountLinkingIntent.HandleBackClicked
 import eu.kevin.accounts.accountlinking.AccountLinkingIntent.Initialize
@@ -19,7 +20,7 @@ import eu.kevin.core.plugin.Kevin
 
 internal class AccountLinkingViewModel(
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<AccountLinkingState, AccountLinkingIntent>(savedStateHandle) {
+) : BaseViewModel<AccountLinkingState, AccountLinkingIntent, AccountLinkingEvent>(savedStateHandle) {
 
     override fun getInitialData() = AccountLinkingState()
 
@@ -63,10 +64,11 @@ internal class AccountLinkingViewModel(
 
         updateState {
             it.copy(
-                bankRedirectUrl = url,
                 accountLinkingType = configuration.linkingType
             )
         }
+
+        sendEvent(LoadWebPage(url))
     }
 
     private fun handleAuthorizationReceived(uri: Uri) {

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionFragment.kt
@@ -17,7 +17,7 @@ import eu.kevin.common.architecture.interfaces.IView
 import eu.kevin.common.extensions.setFragmentResultListener
 
 internal class BankSelectionFragment :
-    BaseFragment<BankSelectionState, BankSelectionIntent, BankSelectionViewModel>(),
+    BaseFragment<BankSelectionState, BankSelectionIntent, Nothing, BankSelectionViewModel>(),
     BankSelectionViewDelegate {
 
     var configuration: BankSelectionFragmentConfiguration? by savedState()
@@ -26,7 +26,7 @@ internal class BankSelectionFragment :
         BankSelectionViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<BankSelectionState> {
+    override fun onCreateView(context: Context): IView<BankSelectionState, Nothing> {
         return BankSelectionView(context).also {
             it.delegate = this
         }

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
@@ -28,7 +28,7 @@ import eu.kevin.common.views.GridListItemDecoration
 
 internal class BankSelectionView(context: Context) :
     BaseView<KevinFragmentBankSelectionBinding>(context),
-    IView<BankSelectionState> {
+    IView<BankSelectionState, Nothing> {
 
     override val binding = KevinFragmentBankSelectionBinding.inflate(LayoutInflater.from(context), this)
 

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionViewModel.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionViewModel.kt
@@ -35,7 +35,7 @@ internal class BankSelectionViewModel constructor(
     private val banksUseCase: GetSupportedBanksUseCase,
     private val dispatchers: CoroutineDispatchers,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<BankSelectionState, BankSelectionIntent>(savedStateHandle) {
+) : BaseViewModel<BankSelectionState, BankSelectionIntent, Nothing>(savedStateHandle) {
 
     override fun getInitialData() = BankSelectionState()
 

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionFragment.kt
@@ -17,7 +17,7 @@ internal class CountrySelectionFragment :
         CountrySelectionViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<CountrySelectionState> {
+    override fun onCreateView(context: Context): IView<CountrySelectionState, *> {
         return CountrySelectionView(context).also {
             it.delegate = this
         }

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionView.kt
@@ -19,7 +19,7 @@ import eu.kevin.common.helpers.SnackbarHelper
 
 internal class CountrySelectionView(context: Context) :
     BaseView<KevinFragmentCountrySelectionBinding>(context),
-    IView<CountrySelectionState> {
+    IView<CountrySelectionState, Nothing> {
 
     override val binding = KevinFragmentCountrySelectionBinding.inflate(LayoutInflater.from(context), this)
 

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionViewModel.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionViewModel.kt
@@ -22,7 +22,7 @@ internal class CountrySelectionViewModel constructor(
     private val countryUseCase: SupportedCountryUseCase,
     private val dispatchers: CoroutineDispatchers,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<CountrySelectionState, CountrySelectionIntent>(savedStateHandle) {
+) : BaseViewModel<CountrySelectionState, CountrySelectionIntent, Nothing>(savedStateHandle) {
 
     override fun getInitialData() = CountrySelectionState()
 

--- a/common/src/main/java/eu/kevin/common/architecture/BaseModalFragment.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseModalFragment.kt
@@ -16,16 +16,16 @@ import eu.kevin.common.architecture.interfaces.Navigable
 import eu.kevin.common.providers.SavedStateProvider
 import kotlinx.coroutines.launch
 
-abstract class BaseModalFragment<S : IState, I : IIntent, M : BaseViewModel<S, I>> :
+abstract class BaseModalFragment<S : IState, I : IIntent, M : BaseViewModel<S, I, *>> :
     BottomSheetDialogFragment(),
     Navigable {
 
     private val savable = Bundle()
 
     protected abstract val viewModel: M
-    protected lateinit var contentView: IView<S>
+    protected lateinit var contentView: IView<S, *>
 
-    abstract fun onCreateView(context: Context): IView<S>
+    abstract fun onCreateView(context: Context): IView<S, *>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {

--- a/common/src/main/java/eu/kevin/common/architecture/BaseViewModel.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/BaseViewModel.kt
@@ -3,6 +3,7 @@ package eu.kevin.common.architecture
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import eu.kevin.common.architecture.interfaces.IEvent
 import eu.kevin.common.architecture.interfaces.IIntent
 import eu.kevin.common.architecture.interfaces.IModel
 import eu.kevin.common.architecture.interfaces.IState
@@ -10,18 +11,22 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-abstract class BaseViewModel<S : IState, I : IIntent>(
+abstract class BaseViewModel<S : IState, I : IIntent, E : IEvent>(
     protected val savedStateHandle: SavedStateHandle
-) : ViewModel(), IModel<S, I> {
+) : ViewModel(), IModel<S, I, E> {
 
     override val intents = Channel<I>(Channel.UNLIMITED)
+
+    private val _state: MutableStateFlow<S>
     override val state: StateFlow<S>
         get() = _state
 
-    private val _state: MutableStateFlow<S>
+    private val _events = Channel<E>(Channel.BUFFERED)
+    override val events = _events.receiveAsFlow()
 
     init {
         _state = MutableStateFlow(getInitialData())
@@ -32,9 +37,8 @@ abstract class BaseViewModel<S : IState, I : IIntent>(
         }
     }
 
-    protected fun getSavedState(): S? {
-        return savedStateHandle.get("saved_state")
-    }
+    protected fun getSavedState(): S? =
+        savedStateHandle.get("saved_state")
 
     protected abstract fun getInitialData(): S
     protected abstract suspend fun handleIntent(intent: I)
@@ -42,5 +46,9 @@ abstract class BaseViewModel<S : IState, I : IIntent>(
     protected suspend fun updateState(handler: suspend (intent: S) -> S) {
         _state.update { handler(_state.value) }
         savedStateHandle.set("saved_state", _state.value)
+    }
+
+    protected suspend fun sendEvent(event: E) {
+        _events.send(event)
     }
 }

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/IEvent.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/IEvent.kt
@@ -1,0 +1,3 @@
+package eu.kevin.common.architecture.interfaces
+
+interface IEvent

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/IModel.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/IModel.kt
@@ -1,9 +1,11 @@
 package eu.kevin.common.architecture.interfaces
 
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
-interface IModel<S : IState, I : IIntent> {
-    val intents: Channel<I>
+interface IModel<S : IState, I : IIntent, E : IEvent> {
     val state: StateFlow<S?>
+    val intents: Channel<I>
+    val events: Flow<E>
 }

--- a/common/src/main/java/eu/kevin/common/architecture/interfaces/IView.kt
+++ b/common/src/main/java/eu/kevin/common/architecture/interfaces/IView.kt
@@ -1,5 +1,6 @@
 package eu.kevin.common.architecture.interfaces
 
-interface IView<S : IState> {
+interface IView<S : IState, E : IEvent> {
     fun render(state: S)
+    fun handleEvent(event: E) = Unit
 }

--- a/demo/src/main/java/eu/kevin/demo/data/database/entities/LinkedAccount.kt
+++ b/demo/src/main/java/eu/kevin/demo/data/database/entities/LinkedAccount.kt
@@ -3,7 +3,7 @@ package eu.kevin.demo.data.database.entities
 import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Entity
 @Parcelize

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsFragment.kt
@@ -22,7 +22,7 @@ internal class AccountActionsFragment :
         viewModel.initialise(configuration!!)
     }
 
-    override fun onCreateView(context: Context): IView<AccountActionsState> {
+    override fun onCreateView(context: Context): IView<AccountActionsState, Nothing> {
         return AccountActionsView(context).also {
             it.callback = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsView.kt
@@ -9,7 +9,7 @@ import eu.kevin.demo.databinding.KevinFragmentAccountActionsBinding
 
 internal class AccountActionsView(context: Context) :
     BaseView<KevinFragmentAccountActionsBinding>(context),
-    IView<AccountActionsState> {
+    IView<AccountActionsState, Nothing> {
 
     override val binding = KevinFragmentAccountActionsBinding.inflate(LayoutInflater.from(context), this)
 

--- a/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsViewModel.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountactions/AccountActionsViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 internal class AccountActionsViewModel(
     private val linkedAccountsDao: LinkedAccountsDao,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<AccountActionsState, AccountActionsIntent>(savedStateHandle) {
+) : BaseViewModel<AccountActionsState, AccountActionsIntent, Nothing>(savedStateHandle) {
 
     private var id: Long? = null
 

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingFragment.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 internal class AccountLinkingFragment :
-    BaseFragment<AccountLinkingState, AccountLinkingIntent, AccountLinkingViewModel>(), AccountLinkingViewCallback {
+    BaseFragment<AccountLinkingState, AccountLinkingIntent, Nothing, AccountLinkingViewModel>(), AccountLinkingViewCallback {
 
     override val viewModel: AccountLinkingViewModel by activityViewModels {
         AccountLinkingViewModel.Factory(
@@ -31,7 +31,7 @@ internal class AccountLinkingFragment :
         viewModel.intents.trySend(OnAccountLinkingResult(result))
     }
 
-    override fun onCreateView(context: Context): IView<AccountLinkingState> {
+    override fun onCreateView(context: Context): IView<AccountLinkingState, Nothing> {
         observeChanges()
         listenForAccountActionSelectedResult()
         return AccountLinkingView(context).also {

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingView.kt
@@ -12,7 +12,7 @@ import eu.kevin.demo.databinding.KevinFragmentLinkAccountBinding
 import eu.kevin.demo.screens.accountlinking.adapters.LinkedAccountsListAdapter
 import eu.kevin.demo.views.DividerItemDecoration
 
-internal class AccountLinkingView(context: Context) : FrameLayout(context), IView<AccountLinkingState> {
+internal class AccountLinkingView(context: Context) : FrameLayout(context), IView<AccountLinkingState, Nothing> {
 
     var callback: AccountLinkingViewCallback? = null
 

--- a/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingViewModel.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/accountlinking/AccountLinkingViewModel.kt
@@ -39,7 +39,7 @@ internal class AccountLinkingViewModel(
     private val linkedAccountsDao: LinkedAccountsDao,
     private val accessTokenPreferences: AccountAccessTokenPreferences,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<AccountLinkingState, AccountLinkingIntent>(savedStateHandle) {
+) : BaseViewModel<AccountLinkingState, AccountLinkingIntent, Nothing>(savedStateHandle) {
 
     private val _viewAction = Channel<AccountLinkingAction>(Channel.BUFFERED)
     val viewAction = _viewAction.receiveAsFlow()

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountFragment.kt
@@ -16,7 +16,7 @@ internal class ChooseAccountFragment :
         )
     }
 
-    override fun onCreateView(context: Context): IView<ChooseAccountState> {
+    override fun onCreateView(context: Context): IView<ChooseAccountState, *> {
         return ChooseAccountView(context).also {
             it.callback = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountView.kt
@@ -11,7 +11,7 @@ import eu.kevin.demo.screens.chooseaccount.adapters.AccountsListAdapter
 
 internal class ChooseAccountView(context: Context) :
     BaseView<KevinFragmentChooseAccountBinding>(context),
-    IView<ChooseAccountState> {
+    IView<ChooseAccountState, Nothing> {
 
     override val binding = KevinFragmentChooseAccountBinding.inflate(LayoutInflater.from(context), this)
 

--- a/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountViewModel.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/chooseaccount/ChooseAccountViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 internal class ChooseAccountViewModel(
     private val linkedAccountsDao: LinkedAccountsDao,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<ChooseAccountState, ChooseAccountIntent>(savedStateHandle) {
+) : BaseViewModel<ChooseAccountState, ChooseAccountIntent, Nothing>(savedStateHandle) {
 
     override fun getInitialData() = ChooseAccountState()
 

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionFragment.kt
@@ -17,7 +17,7 @@ internal class CountrySelectionFragment :
         CountrySelectionViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<CountrySelectionState> {
+    override fun onCreateView(context: Context): IView<CountrySelectionState, *> {
         return CountrySelectionView(context).also {
             it.delegate = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionView.kt
@@ -19,7 +19,7 @@ import eu.kevin.demo.screens.countryselection.helpers.CountryHelper
 
 internal class CountrySelectionView(context: Context) :
     BaseView<KevinFragmentSelectCountryBinding>(context),
-    IView<CountrySelectionState> {
+    IView<CountrySelectionState, Nothing> {
 
     override val binding = KevinFragmentSelectCountryBinding.inflate(LayoutInflater.from(context), this)
 

--- a/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionViewModel.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/countryselection/CountrySelectionViewModel.kt
@@ -20,7 +20,7 @@ internal class CountrySelectionViewModel constructor(
     private val getSupportedCountriesUseCase: GetSupportedCountriesUseCase,
     private val ioDispatcher: CoroutineDispatcher,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<CountrySelectionState, CountrySelectionIntent>(savedStateHandle) {
+) : BaseViewModel<CountrySelectionState, CountrySelectionIntent, Nothing>(savedStateHandle) {
 
     override fun getInitialData() = CountrySelectionState()
 

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentFragment.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 internal class PaymentFragment :
-    BaseFragment<PaymentViewState, PaymentIntent, PaymentViewModel>(),
+    BaseFragment<PaymentViewState, PaymentIntent, Nothing, PaymentViewModel>(),
     PaymentViewCallback {
     override val viewModel: PaymentViewModel by activityViewModels {
         PaymentViewModel.Factory(
@@ -39,7 +39,7 @@ internal class PaymentFragment :
         viewModel.intents.trySend(OnPaymentResult(result))
     }
 
-    override fun onCreateView(context: Context): IView<PaymentViewState> {
+    override fun onCreateView(context: Context): IView<PaymentViewState, Nothing> {
         observeChanges()
         listenForCountrySelectedResult()
         listenForPaymentTypeSelectedResult()

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentView.kt
@@ -33,7 +33,7 @@ import eu.kevin.demo.screens.payment.entities.ValidationResult
 import eu.kevin.demo.screens.payment.entities.exceptions.CreditorNotSelectedException
 import eu.kevin.demo.views.NumberTextWatcher
 
-internal class PaymentView(context: Context) : FrameLayout(context), IView<PaymentViewState> {
+internal class PaymentView(context: Context) : FrameLayout(context), IView<PaymentViewState, Nothing> {
 
     var callback: PaymentViewCallback? = null
 

--- a/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentViewModel.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/payment/PaymentViewModel.kt
@@ -59,7 +59,7 @@ internal class PaymentViewModel constructor(
     private val linkedAccountsDao: LinkedAccountsDao,
     private val initialiseLinkedPaymentUseCase: InitialiseLinkedPaymentUseCase,
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<PaymentViewState, PaymentIntent>(savedStateHandle) {
+) : BaseViewModel<PaymentViewState, PaymentIntent, Nothing>(savedStateHandle) {
 
     private val _viewAction = Channel<PaymentViewAction>(Channel.BUFFERED)
     val viewAction = _viewAction.receiveAsFlow()

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeFragment.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeFragment.kt
@@ -7,8 +7,8 @@ import eu.kevin.common.architecture.interfaces.IView
 import eu.kevin.demo.screens.paymenttype.PaymentTypeIntent.Initialize
 import eu.kevin.demo.screens.paymenttype.PaymentTypeIntent.OnPaymentTypeChosen
 import eu.kevin.demo.screens.paymenttype.enums.DemoPaymentType
-
 internal class PaymentTypeFragment :
+
     BaseModalFragment<PaymentTypeState, PaymentTypeIntent, PaymentTypeViewModel>(),
     PaymentTypeViewCallback {
 
@@ -18,7 +18,7 @@ internal class PaymentTypeFragment :
         PaymentTypeViewModel.Factory(this)
     }
 
-    override fun onCreateView(context: Context): IView<PaymentTypeState> {
+    override fun onCreateView(context: Context): IView<PaymentTypeState, *> {
         return PaymentTypeView(context).also {
             it.callback = this
         }

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeState.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeState.kt
@@ -2,7 +2,7 @@ package eu.kevin.demo.screens.paymenttype
 
 import android.os.Parcelable
 import eu.kevin.common.architecture.interfaces.IState
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class PaymentTypeState(

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeView.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeView.kt
@@ -10,7 +10,7 @@ import eu.kevin.demo.databinding.KevinFragmentPaymentTypeBinding
 
 internal class PaymentTypeView(context: Context) :
     BaseView<KevinFragmentPaymentTypeBinding>(context),
-    IView<PaymentTypeState> {
+    IView<PaymentTypeState, Nothing> {
 
     var callback: PaymentTypeViewCallback? = null
 

--- a/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeViewModel.kt
+++ b/demo/src/main/java/eu/kevin/demo/screens/paymenttype/PaymentTypeViewModel.kt
@@ -11,7 +11,7 @@ import eu.kevin.demo.screens.paymenttype.PaymentTypeIntent.OnPaymentTypeChosen
 
 internal class PaymentTypeViewModel(
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<PaymentTypeState, PaymentTypeIntent>(savedStateHandle) {
+) : BaseViewModel<PaymentTypeState, PaymentTypeIntent, Nothing>(savedStateHandle) {
 
     override fun getInitialData() = PaymentTypeState()
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentEvent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentEvent.kt
@@ -1,0 +1,7 @@
+package eu.kevin.inapppayments.cardpayment
+
+import eu.kevin.common.architecture.interfaces.IEvent
+
+internal sealed class CardPaymentEvent : IEvent {
+    data class LoadWebPage(val url: String) : CardPaymentEvent()
+}

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentFragment.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 internal class CardPaymentFragment :
-    BaseFragment<CardPaymentState, CardPaymentIntent, CardPaymentViewModel>(),
+    BaseFragment<CardPaymentState, CardPaymentIntent, Nothing, CardPaymentViewModel>(),
     CardPaymentViewDelegate {
 
     override val viewModel: CardPaymentViewModel by viewModels {
@@ -35,7 +35,7 @@ internal class CardPaymentFragment :
 
     private lateinit var view: CardPaymentView
 
-    override fun onCreateView(context: Context): IView<CardPaymentState> {
+    override fun onCreateView(context: Context): IView<CardPaymentState, Nothing> {
         return CardPaymentView(context).also {
             it.delegate = this
             view = it

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentFragment.kt
@@ -8,7 +8,7 @@ import eu.kevin.common.architecture.BaseFragment
 import eu.kevin.common.architecture.interfaces.IView
 import eu.kevin.common.extensions.setFragmentResultListener
 import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandleBackClicked
-import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandleCardPaymentEvent
+import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandleCardPaymentWebEvent
 import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandleOnContinueClicked
 import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandlePageFinishedLoading
 import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.HandlePageStartLoading
@@ -18,13 +18,13 @@ import eu.kevin.inapppayments.cardpayment.CardPaymentIntent.Initialize
 import eu.kevin.inapppayments.cardpayment.CardPaymentViewAction.ShowFieldValidations
 import eu.kevin.inapppayments.cardpayment.CardPaymentViewAction.SubmitCardForm
 import eu.kevin.inapppayments.cardpayment.CardPaymentViewAction.SubmitUserRedirect
-import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent
+import eu.kevin.inapppayments.cardpayment.events.CardPaymentWebEvent
 import eu.kevin.inapppayments.cardpaymentredirect.CardPaymentRedirectContract
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 internal class CardPaymentFragment :
-    BaseFragment<CardPaymentState, CardPaymentIntent, Nothing, CardPaymentViewModel>(),
+    BaseFragment<CardPaymentState, CardPaymentIntent, CardPaymentEvent, CardPaymentViewModel>(),
     CardPaymentViewDelegate {
 
     override val viewModel: CardPaymentViewModel by viewModels {
@@ -35,7 +35,7 @@ internal class CardPaymentFragment :
 
     private lateinit var view: CardPaymentView
 
-    override fun onCreateView(context: Context): IView<CardPaymentState, Nothing> {
+    override fun onCreateView(context: Context): IView<CardPaymentState, CardPaymentEvent> {
         return CardPaymentView(context).also {
             it.delegate = this
             view = it
@@ -109,7 +109,7 @@ internal class CardPaymentFragment :
         viewModel.intents.trySend(HandlePaymentResult(uri))
     }
 
-    override fun onEvent(event: CardPaymentEvent) {
-        viewModel.intents.trySend(HandleCardPaymentEvent(event))
+    override fun onWebEvent(event: CardPaymentWebEvent) {
+        viewModel.intents.trySend(HandleCardPaymentWebEvent(event))
     }
 }

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentIntent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentIntent.kt
@@ -2,7 +2,7 @@ package eu.kevin.inapppayments.cardpayment
 
 import android.net.Uri
 import eu.kevin.common.architecture.interfaces.IIntent
-import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent
+import eu.kevin.inapppayments.cardpayment.events.CardPaymentWebEvent
 
 internal sealed class CardPaymentIntent : IIntent {
     object HandleBackClicked : CardPaymentIntent()
@@ -18,6 +18,6 @@ internal sealed class CardPaymentIntent : IIntent {
     data class HandlePaymentResult(
         val uri: Uri
     ) : CardPaymentIntent()
-    data class HandleCardPaymentEvent(val event: CardPaymentEvent) : CardPaymentIntent()
+    data class HandleCardPaymentWebEvent(val event: CardPaymentWebEvent) : CardPaymentIntent()
     data class HandleUserSoftRedirect(val shouldRedirect: Boolean) : CardPaymentIntent()
 }

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentState.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentState.kt
@@ -8,7 +8,6 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class CardPaymentState(
-    val url: String = "",
     val amount: KevinAmount? = null,
     val showCardDetails: Boolean = true,
     val isContinueEnabled: Boolean = false,

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentView.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentView.kt
@@ -40,7 +40,7 @@ import eu.kevin.inapppayments.databinding.KevinFragmentCardPaymentBinding
 
 internal class CardPaymentView(context: Context) :
     BaseView<KevinFragmentCardPaymentBinding>(context),
-    IView<CardPaymentState> {
+    IView<CardPaymentState, Nothing> {
 
     override val binding = KevinFragmentCardPaymentBinding.inflate(LayoutInflater.from(context), this)
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentView.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentView.kt
@@ -27,12 +27,13 @@ import eu.kevin.common.extensions.setOnNextActionListener
 import eu.kevin.common.managers.KeyboardManager
 import eu.kevin.inapppayments.KevinPaymentsPlugin
 import eu.kevin.inapppayments.R
+import eu.kevin.inapppayments.cardpayment.CardPaymentEvent.LoadWebPage
 import eu.kevin.inapppayments.cardpayment.enums.CardPaymentMessage.CARD_PAYMENT_SUBMITTING
 import eu.kevin.inapppayments.cardpayment.enums.CardPaymentMessage.HARD_REDIRECT_MODAL
 import eu.kevin.inapppayments.cardpayment.enums.CardPaymentMessage.SOFT_REDIRECT_MODAL
-import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent.HardRedirect
-import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent.SoftRedirect
-import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent.SubmittingCardData
+import eu.kevin.inapppayments.cardpayment.events.CardPaymentWebEvent.HardRedirect
+import eu.kevin.inapppayments.cardpayment.events.CardPaymentWebEvent.SoftRedirect
+import eu.kevin.inapppayments.cardpayment.events.CardPaymentWebEvent.SubmittingCardData
 import eu.kevin.inapppayments.cardpayment.inputformatters.CardNumberFormatter
 import eu.kevin.inapppayments.cardpayment.inputformatters.DateFormatter
 import eu.kevin.inapppayments.cardpayment.inputvalidation.ValidationResult
@@ -40,12 +41,11 @@ import eu.kevin.inapppayments.databinding.KevinFragmentCardPaymentBinding
 
 internal class CardPaymentView(context: Context) :
     BaseView<KevinFragmentCardPaymentBinding>(context),
-    IView<CardPaymentState, Nothing> {
+    IView<CardPaymentState, CardPaymentEvent> {
 
     override val binding = KevinFragmentCardPaymentBinding.inflate(LayoutInflater.from(context), this)
 
     var delegate: CardPaymentViewDelegate? = null
-    private var previousStateUrl: String? = null
 
     init {
         with(binding.actionBar) {
@@ -130,14 +130,14 @@ internal class CardPaymentView(context: Context) :
                     fun postMessage(message: String) {
                         when (message) {
                             SOFT_REDIRECT_MODAL.value -> {
-                                delegate?.onEvent(
+                                delegate?.onWebEvent(
                                     SoftRedirect(
                                         binding.cardNumberInput.getInputText().removeWhiteSpaces()
                                     )
                                 )
                             }
-                            HARD_REDIRECT_MODAL.value -> delegate?.onEvent(HardRedirect)
-                            CARD_PAYMENT_SUBMITTING.value -> delegate?.onEvent(SubmittingCardData)
+                            HARD_REDIRECT_MODAL.value -> delegate?.onWebEvent(HardRedirect)
+                            CARD_PAYMENT_SUBMITTING.value -> delegate?.onWebEvent(SubmittingCardData)
                         }
                     }
                 },
@@ -173,10 +173,6 @@ internal class CardPaymentView(context: Context) :
 
     override fun render(state: CardPaymentState) {
         with(binding) {
-            if (state.url.isNotBlank() && previousStateUrl != state.url) {
-                previousStateUrl = state.url
-                webView.loadUrl(state.url)
-            }
             binding.continueButton.isEnabled = state.isContinueEnabled
             binding.amountView.text = state.amount?.getDisplayString(context)
             showCardDetails(state.showCardDetails)
@@ -186,6 +182,16 @@ internal class CardPaymentView(context: Context) :
                 binding.progressView.fadeIn()
             } else {
                 binding.progressView.fadeOut()
+            }
+        }
+    }
+
+    override fun handleEvent(event: CardPaymentEvent) {
+        when (event) {
+            is LoadWebPage -> {
+                if (event.url.isNotBlank()) {
+                    binding.webView.loadUrl(event.url)
+                }
             }
         }
     }

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentViewDelegate.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentViewDelegate.kt
@@ -1,7 +1,7 @@
 package eu.kevin.inapppayments.cardpayment
 
 import android.net.Uri
-import eu.kevin.inapppayments.cardpayment.events.CardPaymentEvent
+import eu.kevin.inapppayments.cardpayment.events.CardPaymentWebEvent
 
 internal interface CardPaymentViewDelegate {
     fun onBackClicked()
@@ -14,5 +14,5 @@ internal interface CardPaymentViewDelegate {
     fun onPageStartLoading()
     fun onPageFinishedLoading()
     fun onPaymentResult(uri: Uri)
-    fun onEvent(event: CardPaymentEvent)
+    fun onWebEvent(event: CardPaymentWebEvent)
 }

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentViewModel.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/CardPaymentViewModel.kt
@@ -45,7 +45,7 @@ import java.util.Currency
 internal class CardPaymentViewModel(
     savedStateHandle: SavedStateHandle,
     private val kevinPaymentsClient: KevinPaymentsClient
-) : BaseViewModel<CardPaymentState, CardPaymentIntent>(savedStateHandle) {
+) : BaseViewModel<CardPaymentState, CardPaymentIntent, Nothing>(savedStateHandle) {
     override fun getInitialData() = CardPaymentState()
 
     private val _viewAction = Channel<CardPaymentViewAction>(Channel.BUFFERED)

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/events/CardPaymentEvent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/events/CardPaymentEvent.kt
@@ -1,7 +1,0 @@
-package eu.kevin.inapppayments.cardpayment.events
-
-internal sealed class CardPaymentEvent {
-    data class SoftRedirect(val cardNumber: String) : CardPaymentEvent()
-    object HardRedirect : CardPaymentEvent()
-    object SubmittingCardData : CardPaymentEvent()
-}

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/events/CardPaymentWebEvent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/cardpayment/events/CardPaymentWebEvent.kt
@@ -1,0 +1,7 @@
+package eu.kevin.inapppayments.cardpayment.events
+
+internal sealed class CardPaymentWebEvent {
+    data class SoftRedirect(val cardNumber: String) : CardPaymentWebEvent()
+    object HardRedirect : CardPaymentWebEvent()
+    object SubmittingCardData : CardPaymentWebEvent()
+}

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationEvent.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationEvent.kt
@@ -1,0 +1,7 @@
+package eu.kevin.inapppayments.paymentconfirmation
+
+import eu.kevin.common.architecture.interfaces.IEvent
+
+internal sealed class PaymentConfirmationEvent : IEvent {
+    data class LoadWebPage(val url: String) : PaymentConfirmationEvent()
+}

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
@@ -15,7 +15,7 @@ import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.Hand
 import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.Initialize
 
 internal class PaymentConfirmationFragment :
-    BaseFragment<PaymentConfirmationState, PaymentConfirmationIntent, Nothing, PaymentConfirmationViewModel>(),
+    BaseFragment<PaymentConfirmationState, PaymentConfirmationIntent, PaymentConfirmationEvent, PaymentConfirmationViewModel>(),
     PaymentConfirmationViewDelegate,
     DeepLinkHandler {
 
@@ -27,7 +27,7 @@ internal class PaymentConfirmationFragment :
 
     private lateinit var view: PaymentConfirmationView
 
-    override fun onCreateView(context: Context): IView<PaymentConfirmationState, Nothing> {
+    override fun onCreateView(context: Context): IView<PaymentConfirmationState, PaymentConfirmationEvent> {
         return PaymentConfirmationView(context).also {
             it.delegate = this
             view = it

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
@@ -15,7 +15,7 @@ import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.Hand
 import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.Initialize
 
 internal class PaymentConfirmationFragment :
-    BaseFragment<PaymentConfirmationState, PaymentConfirmationIntent, PaymentConfirmationViewModel>(),
+    BaseFragment<PaymentConfirmationState, PaymentConfirmationIntent, Nothing, PaymentConfirmationViewModel>(),
     PaymentConfirmationViewDelegate,
     DeepLinkHandler {
 
@@ -27,7 +27,7 @@ internal class PaymentConfirmationFragment :
 
     private lateinit var view: PaymentConfirmationView
 
-    override fun onCreateView(context: Context): IView<PaymentConfirmationState> {
+    override fun onCreateView(context: Context): IView<PaymentConfirmationState, Nothing> {
         return PaymentConfirmationView(context).also {
             it.delegate = this
             view = it

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationState.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationState.kt
@@ -5,6 +5,4 @@ import eu.kevin.common.architecture.interfaces.IState
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class PaymentConfirmationState(
-    val url: String = ""
-) : IState, Parcelable
+internal object PaymentConfirmationState : IState, Parcelable

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationView.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationView.kt
@@ -17,17 +17,17 @@ import eu.kevin.common.extensions.hideKeyboard
 import eu.kevin.common.managers.KeyboardManager
 import eu.kevin.inapppayments.KevinPaymentsPlugin
 import eu.kevin.inapppayments.databinding.KevinFragmentPaymentConfirmationBinding
+import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationEvent.LoadWebPage
 
 internal class PaymentConfirmationView(context: Context) :
     BaseView<KevinFragmentPaymentConfirmationBinding>(context),
-    IView<PaymentConfirmationState, Nothing> {
+    IView<PaymentConfirmationState, PaymentConfirmationEvent> {
 
     override val binding = KevinFragmentPaymentConfirmationBinding.inflate(LayoutInflater.from(context), this)
 
     var delegate: PaymentConfirmationViewDelegate? = null
 
     private var lastClickPosition: Int = 0
-    private var previousStateUrl: String? = null
 
     init {
         setBackgroundColor(context.getColorFromAttr(android.R.attr.colorBackground))
@@ -90,10 +90,15 @@ internal class PaymentConfirmationView(context: Context) :
         super.onDetachedFromWindow()
     }
 
-    override fun render(state: PaymentConfirmationState) = with(binding) {
-        if (state.url.isNotBlank() && state.url != previousStateUrl) {
-            confirmationWebView.loadUrl(state.url)
-            previousStateUrl = state.url
+    override fun render(state: PaymentConfirmationState) = Unit
+
+    override fun handleEvent(event: PaymentConfirmationEvent) {
+        when (event) {
+            is LoadWebPage -> {
+                if (event.url.isNotBlank()) {
+                    binding.confirmationWebView.loadUrl(event.url)
+                }
+            }
         }
     }
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationView.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationView.kt
@@ -20,7 +20,7 @@ import eu.kevin.inapppayments.databinding.KevinFragmentPaymentConfirmationBindin
 
 internal class PaymentConfirmationView(context: Context) :
     BaseView<KevinFragmentPaymentConfirmationBinding>(context),
-    IView<PaymentConfirmationState> {
+    IView<PaymentConfirmationState, Nothing> {
 
     override val binding = KevinFragmentPaymentConfirmationBinding.inflate(LayoutInflater.from(context), this)
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationViewModel.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationViewModel.kt
@@ -13,6 +13,7 @@ import eu.kevin.core.plugin.Kevin
 import eu.kevin.inapppayments.BuildConfig
 import eu.kevin.inapppayments.KevinPaymentsPlugin
 import eu.kevin.inapppayments.common.enums.PaymentStatus
+import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationEvent.LoadWebPage
 import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.HandleBackClicked
 import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.HandlePaymentCompleted
 import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationIntent.Initialize
@@ -20,9 +21,9 @@ import eu.kevin.inapppayments.paymentsession.enums.PaymentType.BANK
 
 internal class PaymentConfirmationViewModel(
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<PaymentConfirmationState, PaymentConfirmationIntent, Nothing>(savedStateHandle) {
+) : BaseViewModel<PaymentConfirmationState, PaymentConfirmationIntent, PaymentConfirmationEvent>(savedStateHandle) {
 
-    override fun getInitialData() = PaymentConfirmationState()
+    override fun getInitialData() = PaymentConfirmationState
 
     override suspend fun handleIntent(intent: PaymentConfirmationIntent) {
         when (intent) {
@@ -71,9 +72,8 @@ internal class PaymentConfirmationViewModel(
                     .appendQuery(webFrameQueryParameters)
             }
         }
-        updateState {
-            it.copy(url = url)
-        }
+
+        sendEvent(LoadWebPage(url))
     }
 
     private fun handlePaymentCompleted(uri: Uri) {

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationViewModel.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationViewModel.kt
@@ -20,7 +20,7 @@ import eu.kevin.inapppayments.paymentsession.enums.PaymentType.BANK
 
 internal class PaymentConfirmationViewModel(
     savedStateHandle: SavedStateHandle
-) : BaseViewModel<PaymentConfirmationState, PaymentConfirmationIntent>(savedStateHandle) {
+) : BaseViewModel<PaymentConfirmationState, PaymentConfirmationIntent, Nothing>(savedStateHandle) {
 
     override fun getInitialData() = PaymentConfirmationState()
 

--- a/in-app-payments/src/test/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationViewModelTest.kt
+++ b/in-app-payments/src/test/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationViewModelTest.kt
@@ -5,7 +5,10 @@ import eu.kevin.common.architecture.routing.GlobalRouter
 import eu.kevin.common.extensions.appendQuery
 import eu.kevin.common.fragment.FragmentResult
 import eu.kevin.inapppayments.BuildConfig
+import eu.kevin.inapppayments.KevinPaymentsConfiguration
+import eu.kevin.inapppayments.KevinPaymentsPlugin
 import eu.kevin.inapppayments.common.enums.PaymentStatus
+import eu.kevin.inapppayments.paymentconfirmation.PaymentConfirmationEvent.LoadWebPage
 import eu.kevin.inapppayments.paymentsession.enums.PaymentType
 import eu.kevin.testcore.base.BaseViewModelTest
 import io.mockk.every
@@ -28,6 +31,13 @@ class PaymentConfirmationViewModelTest : BaseViewModelTest() {
     @Before
     override fun setUp() {
         super.setUp()
+
+        KevinPaymentsPlugin.configure(
+            KevinPaymentsConfiguration.builder()
+                .setCallbackUrl("")
+                .build()
+        )
+
         viewModel = PaymentConfirmationViewModel(savedStateHandle)
         every { savedStateHandle.get<Any>(any()) } returns null
     }
@@ -49,9 +59,10 @@ class PaymentConfirmationViewModelTest : BaseViewModelTest() {
         )
 
         val states = mutableListOf<PaymentConfirmationState>()
-        val job = launch {
-            viewModel.state.toList(states)
-        }
+        val events = mutableListOf<PaymentConfirmationEvent>()
+
+        val jobStates = launch { viewModel.state.toList(states) }
+        val jobEvents = launch { viewModel.events.toList(events) }
 
         viewModel.intents.trySend(
             PaymentConfirmationIntent.Initialize(
@@ -60,10 +71,11 @@ class PaymentConfirmationViewModelTest : BaseViewModelTest() {
             )
         )
 
-        Assert.assertEquals(2, states.size)
-        Assert.assertEquals("", states[0].url)
-        Assert.assertEquals(expectedRedirectUrl, states[1].url)
-        job.cancel()
+        Assert.assertEquals(1, states.size)
+        Assert.assertEquals(LoadWebPage(expectedRedirectUrl), events[0])
+
+        jobStates.cancel()
+        jobEvents.cancel()
     }
 
     @Test
@@ -79,9 +91,10 @@ class PaymentConfirmationViewModelTest : BaseViewModelTest() {
         )
 
         val states = mutableListOf<PaymentConfirmationState>()
-        val job = launch {
-            viewModel.state.toList(states)
-        }
+        val events = mutableListOf<PaymentConfirmationEvent>()
+
+        val jobStates = launch { viewModel.state.toList(states) }
+        val jobEvents = launch { viewModel.events.toList(events) }
 
         viewModel.intents.trySend(
             PaymentConfirmationIntent.Initialize(
@@ -90,10 +103,11 @@ class PaymentConfirmationViewModelTest : BaseViewModelTest() {
             )
         )
 
-        Assert.assertEquals(2, states.size)
-        Assert.assertEquals("", states[0].url)
-        Assert.assertEquals(expectedRedirectUrl, states[1].url)
-        job.cancel()
+        Assert.assertEquals(1, states.size)
+        Assert.assertEquals(LoadWebPage(expectedRedirectUrl), events[0])
+
+        jobStates.cancel()
+        jobEvents.cancel()
     }
 
     @Test

--- a/testcore/src/main/java/eu/kevin/testcore/extensions/BaseViewModelExtensions.kt
+++ b/testcore/src/main/java/eu/kevin/testcore/extensions/BaseViewModelExtensions.kt
@@ -1,11 +1,12 @@
 package eu.kevin.testcore.extensions
 
 import eu.kevin.common.architecture.BaseViewModel
+import eu.kevin.common.architecture.interfaces.IEvent
 import eu.kevin.common.architecture.interfaces.IIntent
 import eu.kevin.common.architecture.interfaces.IState
 import kotlinx.coroutines.flow.MutableStateFlow
 
-fun <S : IState, I : IIntent> BaseViewModel<S, I>.updateInternalState(newState: S) {
+fun <S : IState, I : IIntent, E: IEvent> BaseViewModel<S, I, E>.updateInternalState(newState: S) {
     val field = BaseViewModel::class.java.getDeclaredField("_state")
     field.isAccessible = true
     field.set(this, MutableStateFlow(newState))


### PR DESCRIPTION
This PR is proposition of adding Events handling to properly model one-off events like loading a web page etc.

This proposition extends the arch. with IEvent and IView is extended into: 
``` kotlin
interface IView<S : IState, E : IEvent> {
    fun render(state: S)
    fun handleEvent(event: E)
}
```
a downside is that you get a bunch of `Nothing` here and there to handle MVI restrictions for views that do not need events at this moment.

An alternative option would be to extract handleEvent into a separate interface `EventHandler` and only views that need to handle an event would implement it. This also has a downside of some Unchecked Cast in BaseVIewModel and still some `Nothings` in Viewmodels .

Also adding a proposition of unit tests for PR workflow.