### PR TITLE
MOBILE: Ktor update 2.x

### DIFF
--- a/accounts/build.gradle
+++ b/accounts/build.gradle
@@ -24,11 +24,11 @@ android {
         resConfigs("en", "lt", "ru", "bg", "ro", "hu", "el", "et", "pt", "pl", "lv", "sk", "cs", "fi", "sv", "no", "da", "de", "nl", "fr", "es", "it", "sl", "is")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField "String", "KEVIN_ACCOUNTS_API_URL", "\"https://api.kevin.eu\""
+        buildConfigField "String", "KEVIN_ACCOUNTS_API_URL", "\"https://api.kevin.eu/\""
         buildConfigField "String", "KEVIN_LINK_ACCOUNT_URL", "\"https://psd2.kevin.eu/login/%s/%s/preview\""
         buildConfigField "String", "KEVIN_LINK_CARD_URL", "\"https://psd2.kevin.eu/card-details/%s\""
 
-        buildConfigField "String", "KEVIN_SANDBOX_ACCOUNTS_API_URL", "\"https://sandbox-api.getkevin.eu\""
+        buildConfigField "String", "KEVIN_SANDBOX_ACCOUNTS_API_URL", "\"https://sandbox-api.getkevin.eu/\""
         buildConfigField "String", "KEVIN_SANDBOX_LINK_ACCOUNT_URL", "\"https://psd2-sandbox.kevin.eu/login/%s/%s/preview\""
         buildConfigField "String", "KEVIN_SANDBOX_LINK_CARD_URL", "\"https://psd2-sandbox.kevin.eu/card-details/%s\""
 
@@ -40,10 +40,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
-            buildConfigField "io.ktor.client.features.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.features.logging.LogLevel.NONE"
+            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.NONE"
         }
         debug {
-            buildConfigField "io.ktor.client.features.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.features.logging.LogLevel.ALL"
+            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.ALL"
         }
     }
 

--- a/accounts/build.gradle
+++ b/accounts/build.gradle
@@ -40,10 +40,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
-            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.NONE"
+            buildConfigField "eu.kevin.core.enums.KevinLogLevel", "HTTP_LOGGING_LEVEL", "eu.kevin.core.enums.KevinLogLevel.NONE"
         }
         debug {
-            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.ALL"
+            buildConfigField "eu.kevin.core.enums.KevinLogLevel", "HTTP_LOGGING_LEVEL", "eu.kevin.core.enums.KevinLogLevel.ALL"
         }
     }
 

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/adapters/BankListAdapter.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/adapters/BankListAdapter.kt
@@ -57,6 +57,10 @@ internal class BankListAdapter(
             val imageRequest = ImageRequest.Builder(root.context)
                 .data(url)
                 .target(
+                    onStart = {
+                        bankTitleView.visibility = VISIBLE
+                        bankImageView.visibility = INVISIBLE
+                    },
                     onSuccess = {
                         bankImageView.setImageDrawable(it)
                         bankTitleView.visibility = INVISIBLE

--- a/accounts/src/main/java/eu/kevin/accounts/networking/KevinAccountsApiClient.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/networking/KevinAccountsApiClient.kt
@@ -3,6 +3,7 @@ package eu.kevin.accounts.networking
 import eu.kevin.accounts.networking.entities.ApiBank
 import eu.kevin.core.networking.entities.KevinResponse
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 
@@ -11,12 +12,12 @@ internal class KevinAccountsApiClient(
 ) : KevinAccountsClient {
 
     override suspend fun getSupportedCountries(token: String): KevinResponse<String> {
-        return httpClient.get("platform/frame/countries/$token")
+        return httpClient.get("platform/frame/countries/$token").body()
     }
 
     override suspend fun getSupportedBanks(token: String, country: String?): KevinResponse<ApiBank> {
         return httpClient.get("platform/frame/banks/$token") {
             parameter("countryCode", country)
-        }
+        }.body()
     }
 }

--- a/accounts/src/main/java/eu/kevin/accounts/networking/KevinAccountsClientFactory.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/networking/KevinAccountsClientFactory.kt
@@ -1,7 +1,7 @@
 package eu.kevin.accounts.networking
 
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.plugins.logging.LogLevel
 
 /**
  * Factory class for creating [KevinAccountsClient]

--- a/accounts/src/main/java/eu/kevin/accounts/networking/KevinAccountsClientFactory.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/networking/KevinAccountsClientFactory.kt
@@ -1,7 +1,7 @@
 package eu.kevin.accounts.networking
 
+import eu.kevin.core.enums.KevinLogLevel
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.plugins.logging.LogLevel
 
 /**
  * Factory class for creating [KevinAccountsClient]
@@ -14,7 +14,7 @@ class KevinAccountsClientFactory(
     baseUrl: String,
     userAgent: String,
     timeout: Int? = null,
-    logLevel: LogLevel = LogLevel.NONE
+    logLevel: KevinLogLevel = KevinLogLevel.NONE
 ) : BaseApiFactory<KevinAccountsClient>(
     baseUrl,
     userAgent,

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         androidx_core_ktx_version = '1.7.0'
         lifecycle_version = '2.4.1'
         coil_version = '1.4.0'
-        ktor_version = '1.6.8'
+        ktor_version = '2.0.3'
         logback_version = '1.2.11'
         material_version = '1.6.1'
         webkit_version = '1.4.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,7 +64,8 @@ dependencies {
     implementation "com.google.android.material:material:$material_version"
 
     implementation "io.ktor:ktor-client-android:$ktor_version"
-    implementation "io.ktor:ktor-client-serialization:$ktor_version"
+    implementation "io.ktor:ktor-serialization-kotlinx-json:$ktor_version"
+    implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
     implementation "io.ktor:ktor-client-logging:$ktor_version"
 
     testImplementation project(':testcore')

--- a/core/src/main/java/eu/kevin/core/enums/KevinLogLevel.kt
+++ b/core/src/main/java/eu/kevin/core/enums/KevinLogLevel.kt
@@ -1,0 +1,12 @@
+package eu.kevin.core.enums
+
+/**
+ * Level of logs to be used to log network calls.
+ */
+enum class KevinLogLevel {
+    ALL,
+    HEADERS,
+    BODY,
+    INFO,
+    NONE
+}

--- a/core/src/main/java/eu/kevin/core/networking/BaseApiFactory.kt
+++ b/core/src/main/java/eu/kevin/core/networking/BaseApiFactory.kt
@@ -1,5 +1,6 @@
 package eu.kevin.core.networking
 
+import eu.kevin.core.enums.KevinLogLevel
 import eu.kevin.core.networking.exceptions.ApiError
 import eu.kevin.core.networking.exceptions.ErrorResponse
 import eu.kevin.core.networking.serializers.DateSerializer
@@ -30,7 +31,7 @@ abstract class BaseApiFactory<T : BaseApiClient>(
     private val baseUrl: String,
     private val userAgent: String,
     private val timeout: Int? = null,
-    private val logLevel: LogLevel = LogLevel.NONE
+    private val logLevel: KevinLogLevel = KevinLogLevel.NONE
 ) {
 
     private val jsonContentNegotiation = Json {
@@ -81,7 +82,13 @@ abstract class BaseApiFactory<T : BaseApiClient>(
 
             install(Logging) {
                 logger = Logger.ANDROID
-                level = logLevel
+                level = when (logLevel) {
+                    KevinLogLevel.ALL -> LogLevel.ALL
+                    KevinLogLevel.HEADERS -> LogLevel.HEADERS
+                    KevinLogLevel.BODY -> LogLevel.BODY
+                    KevinLogLevel.INFO -> LogLevel.INFO
+                    KevinLogLevel.NONE -> LogLevel.NONE
+                }
             }
         }
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -44,10 +44,10 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
-            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.NONE"
+            buildConfigField "eu.kevin.core.enums.KevinLogLevel", "HTTP_LOGGING_LEVEL", "eu.kevin.core.enums.KevinLogLevel.NONE"
         }
         debug {
-            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.ALL"
+            buildConfigField "eu.kevin.core.enums.KevinLogLevel", "HTTP_LOGGING_LEVEL", "eu.kevin.core.enums.KevinLogLevel.ALL"
         }
     }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -21,14 +21,14 @@ android {
         resConfigs("en", "lt", "ru", "bg", "ro", "hu", "el", "et", "pt", "pl", "lv", "sk", "cs", "fi", "sv", "no", "da", "de", "nl", "fr", "es", "it", "sl", "is")
 
         manifestPlaceholders = [
-            appIcon: "@mipmap/ic_launcher",
-            appIconRound: "@mipmap/ic_launcher_round"
+                appIcon     : "@mipmap/ic_launcher",
+                appIconRound: "@mipmap/ic_launcher_round"
         ]
 
         resValue 'string', 'config_app_name', 'kevin. Demo'
 
-        buildConfigField "String", "KEVIN_API_URL", "\"https://api.getkevin.eu/demo\""
-        buildConfigField "String", "KEVIN_MOBILE_DEMO_API", "\"https://mobile-demo.kevin.eu/api/v1\""
+        buildConfigField "String", "KEVIN_API_URL", "\"https://api.getkevin.eu/demo/\""
+        buildConfigField "String", "KEVIN_MOBILE_DEMO_API_URL", "\"https://mobile-demo.kevin.eu/api/v1/\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -44,10 +44,10 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
-            buildConfigField "io.ktor.client.features.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.features.logging.LogLevel.NONE"
+            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.NONE"
         }
         debug {
-            buildConfigField "io.ktor.client.features.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.features.logging.LogLevel.ALL"
+            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.ALL"
         }
     }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -21,8 +21,8 @@ android {
         resConfigs("en", "lt", "ru", "bg", "ro", "hu", "el", "et", "pt", "pl", "lv", "sk", "cs", "fi", "sv", "no", "da", "de", "nl", "fr", "es", "it", "sl", "is")
 
         manifestPlaceholders = [
-                appIcon     : "@mipmap/ic_launcher",
-                appIconRound: "@mipmap/ic_launcher_round"
+            appIcon: "@mipmap/ic_launcher",
+            appIconRound: "@mipmap/ic_launcher_round"
         ]
 
         resValue 'string', 'config_app_name', 'kevin. Demo'

--- a/demo/src/main/java/eu/kevin/demo/auth/KevinApiClientFactory.kt
+++ b/demo/src/main/java/eu/kevin/demo/auth/KevinApiClientFactory.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.auth
 
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.plugins.logging.LogLevel
 
 internal class KevinApiClientFactory(
     baseUrl: String,

--- a/demo/src/main/java/eu/kevin/demo/auth/KevinApiClientFactory.kt
+++ b/demo/src/main/java/eu/kevin/demo/auth/KevinApiClientFactory.kt
@@ -1,13 +1,13 @@
 package eu.kevin.demo.auth
 
+import eu.kevin.core.enums.KevinLogLevel
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.plugins.logging.LogLevel
 
 internal class KevinApiClientFactory(
     baseUrl: String,
     userAgent: String,
     timeout: Int? = null,
-    logLevel: LogLevel
+    logLevel: KevinLogLevel
 ) : BaseApiFactory<KevinApiClient>(
     baseUrl,
     userAgent,

--- a/demo/src/main/java/eu/kevin/demo/auth/KevinClient.kt
+++ b/demo/src/main/java/eu/kevin/demo/auth/KevinClient.kt
@@ -7,41 +7,43 @@ import eu.kevin.demo.auth.entities.InitiateAuthenticationRequest
 import eu.kevin.demo.auth.entities.InitiatePaymentRequest
 import eu.kevin.demo.auth.entities.RefreshAccessTokenRequest
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal class KevinClient(private val httpClient: HttpClient) : KevinApiClient {
 
     override suspend fun getAccessToken(authorizationCode: String): ApiAccessToken {
         return httpClient.get("auth/tokens/") {
             parameter("authorizationCode", authorizationCode)
-        }
+        }.body()
     }
 
     override suspend fun refreshAccessToken(request: RefreshAccessTokenRequest): ApiAccessToken {
         return httpClient.post("auth/refreshToken/") {
-            body = request
-        }
+            setBody(request)
+        }.body()
     }
 
     override suspend fun getAuthState(request: InitiateAuthenticationRequest): String {
-        return httpClient.post<ApiAuthState>("auth/initiate/") {
-            body = request
-        }.state
+        return httpClient.post("auth/initiate/") {
+            setBody(request)
+        }.body<ApiAuthState>().state
     }
 
     override suspend fun getCardAuthState(): String {
-        return httpClient.post<ApiAuthState>("auth/initiate/card/").state
+        return httpClient.post("auth/initiate/card/").body<ApiAuthState>().state
     }
 
     override suspend fun initializeBankPayment(
         request: InitiatePaymentRequest
     ): ApiPayment {
         return httpClient.post("payments/bank/") {
-            body = request
-        }
+            setBody(request)
+        }.body()
     }
 
     override suspend fun initializeLinkedBankPayment(
@@ -50,15 +52,15 @@ internal class KevinClient(private val httpClient: HttpClient) : KevinApiClient 
     ): ApiPayment {
         return httpClient.post("payments/bank/linked/") {
             header("Authorization", "Bearer $accessToken")
-            body = request
-        }
+            setBody(request)
+        }.body()
     }
 
     override suspend fun initializeCardPayment(
         request: InitiatePaymentRequest
     ): ApiPayment {
         return httpClient.post("payments/card/") {
-            body = request
-        }
+            setBody(request)
+        }.body()
     }
 }

--- a/demo/src/main/java/eu/kevin/demo/data/ClientProvider.kt
+++ b/demo/src/main/java/eu/kevin/demo/data/ClientProvider.kt
@@ -2,7 +2,7 @@ package eu.kevin.demo.data
 
 import eu.kevin.demo.BuildConfig
 import eu.kevin.demo.BuildConfig.KEVIN_API_URL
-import eu.kevin.demo.BuildConfig.KEVIN_MOBILE_DEMO_API
+import eu.kevin.demo.BuildConfig.KEVIN_MOBILE_DEMO_API_URL
 import eu.kevin.demo.auth.KevinApiClient
 import eu.kevin.demo.auth.KevinApiClientFactory
 
@@ -18,7 +18,7 @@ internal object ClientProvider {
 
     val kevinDemoApiClient: KevinApiClient by lazy {
         KevinApiClientFactory(
-            baseUrl = KEVIN_MOBILE_DEMO_API,
+            baseUrl = KEVIN_MOBILE_DEMO_API_URL,
             userAgent = "",
             timeout = 120000,
             logLevel = BuildConfig.HTTP_LOGGING_LEVEL

--- a/demo/src/main/java/eu/kevin/demo/data/KevinDataApiClient.kt
+++ b/demo/src/main/java/eu/kevin/demo/data/KevinDataApiClient.kt
@@ -3,18 +3,19 @@ package eu.kevin.demo.data
 import eu.kevin.demo.data.entities.GetCountriesResponse
 import eu.kevin.demo.data.entities.GetCreditorsResponse
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 
 internal class KevinDataApiClient(private val httpClient: HttpClient) : KevinDataClient {
 
     override suspend fun getSupportedCountries(): GetCountriesResponse {
-        return httpClient.get("countries")
+        return httpClient.get("countries").body()
     }
 
     override suspend fun getCreditorsByCountry(countryCode: String): GetCreditorsResponse {
         return httpClient.get("creditors") {
             parameter("countryCode", countryCode)
-        }
+        }.body()
     }
 }

--- a/demo/src/main/java/eu/kevin/demo/data/KevinDataClientFactory.kt
+++ b/demo/src/main/java/eu/kevin/demo/data/KevinDataClientFactory.kt
@@ -1,7 +1,7 @@
 package eu.kevin.demo.data
 
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.plugins.logging.LogLevel
 
 internal class KevinDataClientFactory(
     baseUrl: String,

--- a/demo/src/main/java/eu/kevin/demo/data/KevinDataClientFactory.kt
+++ b/demo/src/main/java/eu/kevin/demo/data/KevinDataClientFactory.kt
@@ -1,13 +1,13 @@
 package eu.kevin.demo.data
 
+import eu.kevin.core.enums.KevinLogLevel
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.plugins.logging.LogLevel
 
 internal class KevinDataClientFactory(
     baseUrl: String,
     userAgent: String,
     timeout: Int? = null,
-    logLevel: LogLevel
+    logLevel: KevinLogLevel
 ) : BaseApiFactory<KevinDataClient>(
     baseUrl,
     userAgent,

--- a/in-app-payments/build.gradle
+++ b/in-app-payments/build.gradle
@@ -39,10 +39,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.NONE"
+            buildConfigField "eu.kevin.core.enums.KevinLogLevel", "HTTP_LOGGING_LEVEL", "eu.kevin.core.enums.KevinLogLevel.NONE"
         }
         debug {
-            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.ALL"
+            buildConfigField "eu.kevin.core.enums.KevinLogLevel", "HTTP_LOGGING_LEVEL", "eu.kevin.core.enums.KevinLogLevel.ALL"
         }
     }
 

--- a/in-app-payments/build.gradle
+++ b/in-app-payments/build.gradle
@@ -39,10 +39,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField "io.ktor.client.features.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.features.logging.LogLevel.NONE"
+            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.NONE"
         }
         debug {
-            buildConfigField "io.ktor.client.features.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.features.logging.LogLevel.ALL"
+            buildConfigField "io.ktor.client.plugins.logging.LogLevel", "HTTP_LOGGING_LEVEL", "io.ktor.client.plugins.logging.LogLevel.ALL"
         }
     }
 

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/networking/KevinPaymentsApiClient.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/networking/KevinPaymentsApiClient.kt
@@ -3,6 +3,7 @@ package eu.kevin.inapppayments.networking
 import eu.kevin.accounts.networking.entities.ApiBank
 import eu.kevin.inapppayments.networking.entities.CardPaymentInfo
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 
 internal class KevinPaymentsApiClient(
@@ -10,10 +11,10 @@ internal class KevinPaymentsApiClient(
 ) : KevinPaymentsClient {
 
     override suspend fun getCardPaymentInfo(paymentId: String): CardPaymentInfo {
-        return httpClient.get("platform/frame/card/payment/$paymentId")
+        return httpClient.get("platform/frame/card/payment/$paymentId").body()
     }
 
     override suspend fun getBankFromCardNumber(paymentId: String, cardNumberPart: String): ApiBank {
-        return httpClient.get("platform/frame/banks/cards/$paymentId/$cardNumberPart")
+        return httpClient.get("platform/frame/banks/cards/$paymentId/$cardNumberPart").body()
     }
 }

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/networking/KevinPaymentsClientFactory.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/networking/KevinPaymentsClientFactory.kt
@@ -1,7 +1,7 @@
 package eu.kevin.inapppayments.networking
 
+import eu.kevin.core.enums.KevinLogLevel
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.plugins.logging.LogLevel
 
 /**
  * Factory class for creating [KevinPaymentsClient]
@@ -14,7 +14,7 @@ class KevinPaymentsClientFactory(
     baseUrl: String,
     userAgent: String,
     timeout: Int? = null,
-    logLevel: LogLevel = LogLevel.NONE
+    logLevel: KevinLogLevel = KevinLogLevel.NONE
 ) : BaseApiFactory<KevinPaymentsClient>(
     baseUrl,
     userAgent,

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/networking/KevinPaymentsClientFactory.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/networking/KevinPaymentsClientFactory.kt
@@ -1,7 +1,7 @@
 package eu.kevin.inapppayments.networking
 
 import eu.kevin.core.networking.BaseApiFactory
-import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.plugins.logging.LogLevel
 
 /**
  * Factory class for creating [KevinPaymentsClient]


### PR DESCRIPTION
This PR updates Ktor to latest version along with all necessary migrations:

https://ktor.io/docs/migrating-2.html#169ebc8a

Also Ktor's owned LogLevel is now hidden behind Kevin enum as there is no need to expose Ktor's imports above :core module.