### PR TITLE
MOBILE-2669: Continue button visibility

### DIFF
--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionState.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionState.kt
@@ -10,6 +10,7 @@ import kotlinx.parcelize.Parcelize
 internal data class BankSelectionState(
     val selectedCountry: String = "",
     val isCountrySelectionDisabled: Boolean = true,
+    val isContinueVisible: Boolean = true,
     val bankListItems: List<BankListItem> = emptyList(),
     val loadingState: LoadingState? = null
 ) : IState, Parcelable

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
@@ -77,6 +77,7 @@ internal class BankSelectionView(context: Context) :
 
     override fun render(state: BankSelectionState) = with(requireBinding()) {
         banksAdapter.updateItems(state.bankListItems)
+        bottomContainer.visibility = if (state.isContinueVisible) VISIBLE else GONE
         countrySelectionView.image = CountryHelper.getCountryFlagDrawable(context, state.selectedCountry)
         countrySelectionView.title = CountryHelper.getCountryName(context, state.selectedCountry)
         emptyStateTitle.text = context.getString(

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionView.kt
@@ -88,7 +88,6 @@ internal class BankSelectionView(context: Context) :
         showCountrySelection(!state.isCountrySelectionDisabled)
         when (state.loadingState) {
             is LoadingState.Loading -> startLoading(state.loadingState.isLoading)
-            is LoadingState.FailureWithMessage -> showErrorMessage(state.loadingState.message)
             is LoadingState.Failure -> showFailure(state.loadingState.error)
             null -> startLoading(false)
         }

--- a/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionViewModel.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/bankselection/BankSelectionViewModel.kt
@@ -110,12 +110,18 @@ internal class BankSelectionViewModel constructor(
                     Bank(it.id, it.name, it.officialName, it.imageUri, it.bic)
                 }
 
+                val bankListItems = BankListItemFactory.getBankList(
+                    apiBanks = apiBanks,
+                    selectedBankId = configuration.selectedBankId
+                )
+
                 updateState {
                     it.copy(
                         selectedCountry = selectedCountry,
                         isCountrySelectionDisabled = disableCountrySelection,
+                        isContinueVisible = bankListItems.any { item -> item.isSelected },
                         loadingState = LoadingState.Loading(false),
-                        bankListItems = BankListItemFactory.getBankList(apiBanks, configuration.selectedBankId)
+                        bankListItems = bankListItems
                     )
                 }
             } catch (e: Exception) {
@@ -129,10 +135,12 @@ internal class BankSelectionViewModel constructor(
 
     private suspend fun handleBankSelection(bankId: String) {
         updateState { oldState ->
+            val bankListItems = state.value.bankListItems.map {
+                it.copy(isSelected = it.bankId == bankId)
+            }
             oldState.copy(
-                bankListItems = state.value.bankListItems.map {
-                    it.copy(isSelected = it.bankId == bankId)
-                }
+                bankListItems = bankListItems,
+                isContinueVisible = bankListItems.any { it.isSelected }
             )
         }
     }
@@ -168,12 +176,14 @@ internal class BankSelectionViewModel constructor(
                 banks = apiBanks.map {
                     Bank(it.id, it.name, it.officialName, it.imageUri, it.bic)
                 }
+                val bankListItems = BankListItemFactory.getBankList(apiBanks)
 
                 updateState {
                     it.copy(
                         selectedCountry = selectedCountry,
                         loadingState = LoadingState.Loading(false),
-                        bankListItems = BankListItemFactory.getBankList(apiBanks)
+                        bankListItems = bankListItems,
+                        isContinueVisible = bankListItems.any { item -> item.isSelected }
                     )
                 }
             } catch (e: Exception) {

--- a/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionView.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/countryselection/CountrySelectionView.kt
@@ -43,7 +43,6 @@ internal class CountrySelectionView(context: Context) :
     override fun render(state: CountrySelectionState) = with(requireBinding()) {
         when (state.loadingState) {
             is LoadingState.Loading -> showLoading(state.loadingState.isLoading())
-            is LoadingState.FailureWithMessage -> showError(state.loadingState.message)
             is LoadingState.Failure -> {
                 showError(ErrorHelper.getMessage(context, state.loadingState.error))
             }

--- a/accounts/src/test/java/eu/kevin/accounts/bankselection/BankSelectionViewModelTest.kt
+++ b/accounts/src/test/java/eu/kevin/accounts/bankselection/BankSelectionViewModelTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -225,6 +226,7 @@ class BankSelectionViewModelTest : BaseViewModelTest() {
             assertEquals(LoadingState.Loading(true), states[1].loadingState)
             assertEquals(LoadingState.Loading(false), states[2].loadingState)
             assertTrue(states[2].bankListItems.isEmpty())
+            assertFalse(states[2].isContinueVisible)
             assertEquals(false, states[2].isCountrySelectionDisabled)
             assertEquals("at", states[2].selectedCountry)
             job.cancel()
@@ -262,6 +264,7 @@ class BankSelectionViewModelTest : BaseViewModelTest() {
         viewModel.intents.trySend(BankSelectionIntent.HandleBankSelection(preselectedBank))
 
         assertTrue(states[0].bankListItems.firstOrNull { it.isSelected }?.bankId != preselectedBank)
+        assertTrue(states[0].isContinueVisible)
 
         job.cancel()
     }

--- a/common/src/main/java/eu/kevin/common/entities/LoadingState.kt
+++ b/common/src/main/java/eu/kevin/common/entities/LoadingState.kt
@@ -4,13 +4,12 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 sealed class LoadingState : Parcelable {
+
     @Parcelize
     data class Loading(val isLoading: Boolean) : LoadingState()
 
     @Parcelize
     data class Failure(val error: Throwable) : LoadingState()
-
-    @Parcelize
-    data class FailureWithMessage(val message: String) : LoadingState()
 }
+
 fun LoadingState?.isLoading(): Boolean = (this as? LoadingState.Loading)?.isLoading == true


### PR DESCRIPTION
- This PR hides continue button section completely if no banks are available to select. Behavior will now be consistent with iOS.
- Also removes unused loading state `FailureWithMessage`