### PR TITLE
MOBILE-2086: Crash during account linking if "Don't keep activities"

### DIFF
--- a/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingFragment.kt
+++ b/accounts/src/main/java/eu/kevin/accounts/accountlinking/AccountLinkingFragment.kt
@@ -88,12 +88,12 @@ internal class AccountLinkingFragment :
 
     override fun openAppIfAvailable(uri: Uri): Boolean {
         if (!Kevin.isDeepLinkingEnabled()) return false
-        val intent = IntentHandlerHelper.getIntentForUri(requireContext(), uri) ?: return false
-        return try {
+        try {
+            val intent = IntentHandlerHelper.getIntentForUri(requireContext(), uri) ?: return false
             startActivity(intent)
-            true
+            return true
         } catch (ignored: Exception) {
-            false
+            return false
         }
     }
 }

--- a/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
+++ b/in-app-payments/src/main/java/eu/kevin/inapppayments/paymentconfirmation/PaymentConfirmationFragment.kt
@@ -89,12 +89,12 @@ internal class PaymentConfirmationFragment :
 
     override fun openAppIfAvailable(uri: Uri): Boolean {
         if (!Kevin.isDeepLinkingEnabled()) return false
-        val intent = IntentHandlerHelper.getIntentForUri(requireContext(), uri) ?: return false
-        return try {
+        try {
+            val intent = IntentHandlerHelper.getIntentForUri(requireContext(), uri) ?: return false
             startActivity(intent)
-            true
+            return true
         } catch (ignored: Exception) {
-            false
+            return false
         }
     }
 }


### PR DESCRIPTION
It's not solution to the very root of the problem but context check there fixes the issue at hand and won't hurt anyway.

The root cause is deeper. Since `Don't keep activities` developer option is used the AccountSession is recreated when coming back from Revolut (for example) app and webView is initiated once again and so on. in the meantime deeplink is able to close the activity with the result. 

But that's a story for another task.