### PR TITLE
Disable javadoc generation (AGP issue workaround)

### DIFF
--- a/accounts/build.gradle
+++ b/accounts/build.gradle
@@ -59,7 +59,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
+            // withJavadocJar()
         }
     }
 

--- a/accounts/build.gradle
+++ b/accounts/build.gradle
@@ -59,7 +59,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            // withJavadocJar()
+            // withJavadocJar() https://github.com/Kotlin/dokka/issues/2956
         }
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -48,7 +48,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
+            // withJavadocJar()
         }
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -48,7 +48,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            // withJavadocJar()
+            // withJavadocJar() https://github.com/Kotlin/dokka/issues/2956
         }
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,7 +46,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            // withJavadocJar()
+            // withJavadocJar() https://github.com/Kotlin/dokka/issues/2956
         }
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,7 +46,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
+            // withJavadocJar()
         }
     }
 

--- a/in-app-payments/build.gradle
+++ b/in-app-payments/build.gradle
@@ -58,7 +58,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            // withJavadocJar()
+            // withJavadocJar() https://github.com/Kotlin/dokka/issues/2956
         }
     }
 

--- a/in-app-payments/build.gradle
+++ b/in-app-payments/build.gradle
@@ -58,7 +58,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
+            // withJavadocJar()
         }
     }
 

--- a/testcore/build.gradle
+++ b/testcore/build.gradle
@@ -40,7 +40,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
+            // withJavadocJar()
         }
     }
 

--- a/testcore/build.gradle
+++ b/testcore/build.gradle
@@ -40,7 +40,7 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            // withJavadocJar()
+            // withJavadocJar() https://github.com/Kotlin/dokka/issues/2956
         }
     }
 


### PR DESCRIPTION
Original error while publishing:
https://github.com/getkevin/kevin-android/actions/runs/6246403050/job/16956940338?ts=2#step:4:131

Probable cause:
https://github.com/Kotlin/dokka/issues/2956

Workaround:
To continue with release disable javadoc for publishing. I think we are not using HTML anywhere. IDE quickdoc is taken from sources.

I could not find better option for this moment. I don't think reverting to JDK 11 is a good way now.